### PR TITLE
SELECT Query: Full-table Scan

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -303,35 +303,6 @@ func (db *DB) serialiseInsertIntoTableInput(insertIntoTableInput sqlparser.Inser
 	return fmt.Sprintf("%s:%s", tableName, primaryKeyValue), valueSchemaBuf, nil
 }
 
-// value: [value1][size_of_value2][value2][value3]
-func (db *DB) deserializeRowValues(tableName, value string) ([]string, error) {
-	// read byte inputs
-	schema := db.tableNameVsSchemaMap[tableName]
-	valueBuf := []byte(value)
-	i := 0
-	rowValues := []string{}
-	for _, col := range schema.ColumnDetails {
-		switch col.DataType {
-		case sqlparser.Int:
-			val := strconv.FormatUint(uint64(binary.BigEndian.Uint32(valueBuf[i:i+4])), 10)
-			rowValues = append(rowValues, val)
-			i += 4
-		case sqlparser.String:
-			len := int(binary.BigEndian.Uint32(valueBuf[i : i+4]))
-			i += 4
-			val := string(valueBuf[i : i+len])
-			rowValues = append(rowValues, val)
-			i += len
-
-		case sqlparser.Bool:
-			val := strconv.FormatUint(uint64(valueBuf[i]), 2)
-			rowValues = append(rowValues, val)
-			i++
-		}
-	}
-	return rowValues, nil
-}
-
 func (db *DB) insertIntoTable(insertIntoTableInput sqlparser.InsertIntoTable) error {
 	table := db.tableNameVsSchemaMap[insertIntoTableInput.TableName]
 	if len(insertIntoTableInput.ColumnValues) != len(table.ColumnDetails) {
@@ -342,46 +313,6 @@ func (db *DB) insertIntoTable(insertIntoTableInput sqlparser.InsertIntoTable) er
 		return err
 	}
 	return db.Put(key, string(valueSchemaBuf))
-}
-
-func (db *DB) selectFromTable(selectFromTableInput sqlparser.SelectFromTable) ([][]string, error) {
-	// what should be the output structure?
-	// array of rows ==> [][]string?
-	// only support primary key based queries for now
-	// we need to know the primary key column
-	tableName := selectFromTableInput.TableName
-	schema, ok := db.tableNameVsSchemaMap[selectFromTableInput.TableName]
-	pkPos := schema.PrimaryKeyColumnPosition
-	pkColumnName := ""
-	if !ok {
-		return nil, fmt.Errorf("table with name %q not found", tableName)
-	}
-	// improve performance by storing primary key column name also?
-	for i, col := range schema.ColumnDetails {
-		if i == pkPos {
-			pkColumnName = col.ColumnName
-		}
-	}
-	if pkColumnName == "" {
-		// throw error?
-		return nil, errors.New("primary key column position is incorrect")
-	}
-	// only pointed primary key query supported
-	if len(selectFromTableInput.QueryConditions) == 1 && selectFromTableInput.QueryConditions[0].ColumnName == pkColumnName &&
-		selectFromTableInput.QueryConditions[0].QueryType == sqlparser.Equals {
-		// todo: check for columns required
-		key := fmt.Sprintf("%s:%s", tableName, selectFromTableInput.QueryConditions[0].Value)
-		value, err := db.Get(key)
-		if err != nil {
-			return nil, err
-		}
-		rowValues, err := db.deserializeRowValues(tableName, value)
-		if err != nil {
-			return nil, err
-		}
-		return [][]string{rowValues}, nil
-	}
-	return nil, errors.New("query not supported")
 }
 
 func (db *DB) ShowTables() []string {

--- a/db/insert_select_test.go
+++ b/db/insert_select_test.go
@@ -55,23 +55,28 @@ func TestSelectFullTableScan(t *testing.T) {
 	// insert few rows in student table
 	for i := 0; i < 50; i++ {
 		err = db.InsertIntoTable(fmt.Sprintf("INSERT INTO student VALUES (%d, id%d, 1)", i, i))
+		assert.NoError(t, err)
 	}
 
 	for i := 75; i < 120; i++ {
 		err = db.InsertIntoTable(fmt.Sprintf("INSERT INTO teacher VALUES (%d, id%d, 1)", i, i))
+		assert.NoError(t, err)
 	}
 
 	val, ok := db.memTable.Get("student:id0")
 	fmt.Printf("val111: %v %v\n", val, ok)
 
-	_, err = db.selectFromTable(sqlparser.SelectFromTable{
+	studentTableScan, err := db.selectFromTable(sqlparser.SelectFromTable{
 		TableName:       "student",
 		ColumnsRequired: []string{"*"},
 	})
 
-	_, err = db.selectFromTable(sqlparser.SelectFromTable{
+	fmt.Printf("studentTableScan: %+v\n", studentTableScan)
+
+	teacherTableScan, err := db.selectFromTable(sqlparser.SelectFromTable{
 		TableName:       "teacher",
 		ColumnsRequired: []string{"*"},
 	})
+	fmt.Printf("teacherTableScan: %+v\n", teacherTableScan)
 	assert.NoError(t, err)
 }

--- a/db/insert_select_test.go
+++ b/db/insert_select_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
 	sqlparser "github.com/golang-db/sql_parser"
@@ -36,47 +37,47 @@ func TestInsertSelectTestWithPrimaryKey(t *testing.T) {
 	assert.Equal(t, []string{"15", "id1234", "1"}, res[0])
 }
 
+// create 5 different tables.
+// insert few rows in each. do a full table scan of each of them separately and assert result.
 func TestSelectFullTableScan(t *testing.T) {
-	// create 4 different tables.
-	// insert few rows in each. do a full table scan of each of them separately.
 	db, cleanupFunc, err := newDBForTest()
 	defer cleanupFunc()
 	assert.NoError(t, err)
 
-	err = db.CreateTable("CREATE TABLE customer (age INT, id STRING, isActive BOOL, PRIMARY KEY (id));")
-	assert.NoError(t, err)
-	err = db.CreateTable("CREATE TABLE employee (age INT, id STRING, isActive BOOL, PRIMARY KEY (id));")
-	assert.NoError(t, err)
-	err = db.CreateTable("CREATE TABLE student (age INT, id STRING, isActive BOOL, PRIMARY KEY (id));")
-	assert.NoError(t, err)
-	err = db.CreateTable("CREATE TABLE teacher (age INT, id STRING, isActive BOOL, PRIMARY KEY (id));")
-	assert.NoError(t, err)
+	tableNames := []string{"customer", "employee", "student", "studentDetails", "teacher"}
 
-	// insert few rows in student table
-	for i := 0; i < 50; i++ {
-		err = db.InsertIntoTable(fmt.Sprintf("INSERT INTO student VALUES (%d, id%d, 1)", i, i))
+	for _, tableName := range tableNames {
+		err = db.CreateTable(fmt.Sprintf("CREATE TABLE %s (age INT, id STRING, isActive BOOL, PRIMARY KEY (id));", tableName))
 		assert.NoError(t, err)
 	}
 
-	for i := 75; i < 120; i++ {
-		err = db.InsertIntoTable(fmt.Sprintf("INSERT INTO teacher VALUES (%d, id%d, 1)", i, i))
+	j := -1
+	for i := 0; i < 100; i++ {
+		if i%20 == 0 {
+			j++
+		}
+		err = db.InsertIntoTable(fmt.Sprintf("INSERT INTO %s VALUES (%d, id%d, 1)", tableNames[j], i, i))
 		assert.NoError(t, err)
 	}
 
-	val, ok := db.memTable.Get("student:id0")
-	fmt.Printf("val111: %v %v\n", val, ok)
-
-	studentTableScan, err := db.selectFromTable(sqlparser.SelectFromTable{
-		TableName:       "student",
-		ColumnsRequired: []string{"*"},
-	})
-
-	fmt.Printf("studentTableScan: %+v\n", studentTableScan)
-
-	teacherTableScan, err := db.selectFromTable(sqlparser.SelectFromTable{
-		TableName:       "teacher",
-		ColumnsRequired: []string{"*"},
-	})
-	fmt.Printf("teacherTableScan: %+v\n", teacherTableScan)
+	for i, tableName := range tableNames {
+		tableScan, err := db.selectFromTable(sqlparser.SelectFromTable{
+			TableName:       tableName,
+			ColumnsRequired: []string{"*"},
+		})
+		assert.NoError(t, err)
+		expectedValStart := (i * 20)
+		expectedValEnd := (i * 20) + 19
+		assert.Len(t, tableScan, 20)
+		for _, row := range tableScan {
+			assert.Len(t, row, 3)
+			age, err := strconv.Atoi(row[0])
+			assert.NoError(t, err)
+			assert.GreaterOrEqual(t, age, expectedValStart)
+			assert.LessOrEqual(t, age, expectedValEnd)
+			assert.Equal(t, row[1], fmt.Sprintf("id%s", row[0]))
+			assert.Equal(t, row[2], "1")
+		}
+	}
 	assert.NoError(t, err)
 }

--- a/db/insert_select_test.go
+++ b/db/insert_select_test.go
@@ -1,13 +1,14 @@
 package db
 
 import (
+	"fmt"
 	"testing"
 
 	sqlparser "github.com/golang-db/sql_parser"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestInsertSelectTest(t *testing.T) {
+func TestInsertSelectTestWithPrimaryKey(t *testing.T) {
 	db, cleanupFunc, err := newDBForTest()
 	defer cleanupFunc()
 	assert.NoError(t, err)
@@ -33,4 +34,44 @@ func TestInsertSelectTest(t *testing.T) {
 	assert.Len(t, res, 1)
 
 	assert.Equal(t, []string{"15", "id1234", "1"}, res[0])
+}
+
+func TestSelectFullTableScan(t *testing.T) {
+	// create 4 different tables.
+	// insert few rows in each. do a full table scan of each of them separately.
+	db, cleanupFunc, err := newDBForTest()
+	defer cleanupFunc()
+	assert.NoError(t, err)
+
+	err = db.CreateTable("CREATE TABLE customer (age INT, id STRING, isActive BOOL, PRIMARY KEY (id));")
+	assert.NoError(t, err)
+	err = db.CreateTable("CREATE TABLE employee (age INT, id STRING, isActive BOOL, PRIMARY KEY (id));")
+	assert.NoError(t, err)
+	err = db.CreateTable("CREATE TABLE student (age INT, id STRING, isActive BOOL, PRIMARY KEY (id));")
+	assert.NoError(t, err)
+	err = db.CreateTable("CREATE TABLE teacher (age INT, id STRING, isActive BOOL, PRIMARY KEY (id));")
+	assert.NoError(t, err)
+
+	// insert few rows in student table
+	for i := 0; i < 50; i++ {
+		err = db.InsertIntoTable(fmt.Sprintf("INSERT INTO student VALUES (%d, id%d, 1)", i, i))
+	}
+
+	for i := 75; i < 120; i++ {
+		err = db.InsertIntoTable(fmt.Sprintf("INSERT INTO teacher VALUES (%d, id%d, 1)", i, i))
+	}
+
+	val, ok := db.memTable.Get("student:id0")
+	fmt.Printf("val111: %v %v\n", val, ok)
+
+	_, err = db.selectFromTable(sqlparser.SelectFromTable{
+		TableName:       "student",
+		ColumnsRequired: []string{"*"},
+	})
+
+	_, err = db.selectFromTable(sqlparser.SelectFromTable{
+		TableName:       "teacher",
+		ColumnsRequired: []string{"*"},
+	})
+	assert.NoError(t, err)
 }

--- a/db/select.go
+++ b/db/select.go
@@ -84,7 +84,6 @@ func (db *DB) deserializeRowValues(tableName, value string) ([]string, error) {
 }
 
 func (db *DB) fullTableScan(tableName string) ([][]string, error) {
-	// do a prefix scan on memtable
 	key := fmt.Sprintf("%s:", tableName)
 	memTableMap := db.memTable.FullTableScan(key)
 
@@ -93,7 +92,7 @@ func (db *DB) fullTableScan(tableName string) ([][]string, error) {
 		return nil, err
 	}
 
-	fmt.Printf("memTableMap111: %v\n", memTableMap)
-	fmt.Printf("ssTableMap111: %v\n", ssTableMap)
+	fmt.Printf("memTableMap111: %+v\n", memTableMap)
+	fmt.Printf("ssTableMap111: %+v\n", ssTableMap)
 	return nil, nil
 }

--- a/db/select.go
+++ b/db/select.go
@@ -92,7 +92,28 @@ func (db *DB) fullTableScan(tableName string) ([][]string, error) {
 		return nil, err
 	}
 
+	scanOutput := [][]string{}
+	for _, value := range memTableMap {
+		values, err := db.deserializeRowValues(tableName, value)
+		if err != nil {
+			return nil, err
+		}
+		scanOutput = append(scanOutput, values)
+	}
+
+	for key, value := range ssTableMap {
+		if _, ok := memTableMap[key]; ok {
+			// memtable would have the most up-to date value. no need to rely on sstable value when key is found in memtable
+			continue
+		}
+		values, err := db.deserializeRowValues(tableName, value)
+		if err != nil {
+			return nil, err
+		}
+		scanOutput = append(scanOutput, values)
+	}
+
 	fmt.Printf("memTableMap111: %+v\n", memTableMap)
 	fmt.Printf("ssTableMap111: %+v\n", ssTableMap)
-	return nil, nil
+	return scanOutput, nil
 }

--- a/db/select.go
+++ b/db/select.go
@@ -1,0 +1,99 @@
+package db
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"strconv"
+
+	sqlparser "github.com/golang-db/sql_parser"
+)
+
+func (db *DB) selectFromTable(selectFromTableInput sqlparser.SelectFromTable) ([][]string, error) {
+	// what should be the output structure?
+	// array of rows ==> [][]string?
+	// only support primary key based queries for now
+	// we need to know the primary key column
+	tableName := selectFromTableInput.TableName
+	schema, ok := db.tableNameVsSchemaMap[selectFromTableInput.TableName]
+	pkPos := schema.PrimaryKeyColumnPosition
+	pkColumnName := ""
+	if !ok {
+		return nil, fmt.Errorf("table with name %q not found", tableName)
+	}
+	// improve performance by storing primary key column name also?
+	for i, col := range schema.ColumnDetails {
+		if i == pkPos {
+			pkColumnName = col.ColumnName
+		}
+	}
+	if pkColumnName == "" {
+		// throw error?
+		return nil, errors.New("primary key column position is incorrect")
+	}
+	// only pointed primary key query supported
+	if len(selectFromTableInput.QueryConditions) == 1 && selectFromTableInput.QueryConditions[0].ColumnName == pkColumnName &&
+		selectFromTableInput.QueryConditions[0].QueryType == sqlparser.Equals {
+		// todo: check for columns required
+		key := fmt.Sprintf("%s:%s", tableName, selectFromTableInput.QueryConditions[0].Value)
+		value, err := db.Get(key)
+		if err != nil {
+			return nil, err
+		}
+		rowValues, err := db.deserializeRowValues(tableName, value)
+		if err != nil {
+			return nil, err
+		}
+		return [][]string{rowValues}, nil
+	}
+	// full-table scan
+	// todo: not solving for returning limited columns right now
+	if len(selectFromTableInput.QueryConditions) == 0 {
+		return db.fullTableScan(tableName)
+	}
+	return nil, errors.New("query not supported")
+}
+
+// value: [value1][size_of_value2][value2][value3]
+func (db *DB) deserializeRowValues(tableName, value string) ([]string, error) {
+	// read byte inputs
+	schema := db.tableNameVsSchemaMap[tableName]
+	valueBuf := []byte(value)
+	i := 0
+	rowValues := []string{}
+	for _, col := range schema.ColumnDetails {
+		switch col.DataType {
+		case sqlparser.Int:
+			val := strconv.FormatUint(uint64(binary.BigEndian.Uint32(valueBuf[i:i+4])), 10)
+			rowValues = append(rowValues, val)
+			i += 4
+		case sqlparser.String:
+			len := int(binary.BigEndian.Uint32(valueBuf[i : i+4]))
+			i += 4
+			val := string(valueBuf[i : i+len])
+			rowValues = append(rowValues, val)
+			i += len
+
+		case sqlparser.Bool:
+			val := strconv.FormatUint(uint64(valueBuf[i]), 2)
+			rowValues = append(rowValues, val)
+			i++
+		}
+	}
+	return rowValues, nil
+}
+
+func (db *DB) fullTableScan(tableName string) ([][]string, error) {
+	// do a prefix scan on memtable
+	key := fmt.Sprintf("%s:", tableName)
+	memTableMap := db.memTable.FullTableScan(key)
+
+	ssTableMap, err := db.ssTable.FullTableScan(key)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("memTableMap111: %v\n", memTableMap)
+	fmt.Printf("ssTableMap111: %v\n", ssTableMap)
+	return nil, nil
+}

--- a/docs/journal/part_8_sql_v2.md
+++ b/docs/journal/part_8_sql_v2.md
@@ -56,8 +56,14 @@
     - Key here also would be `table_name:` and as soon as the prefix changes, we stop reading from the memtable.
 - **Open Questions**:
     - Claude had highlighted in a session that certain databases use merge iterator which makes the time complexity O (N logK). Didn't understand it. Let's discuss if there are more performant ways of doing this.
+- **Todo list:**
+    - Tombstone handling and delete support.
+    - We are building the entire result-set in-memory in map. What if there are billions of rows in a table?
+    - **Merge iterator**: How can this solution improve our performance? Does this provide parallel reads and then merge instead of going sequential?
+    - **Transaction isolation during scan**:
+        - What happens if writes are going in parallel when we are running full-table scan? 
 
-### Prefix approach vs Per-table SS-Table Instance
+### Todo: Prefix approach vs Per-table SS-Table Instance
 - Creating a separate ss-table could be a little bit more performant as we would not be requiring to go through index block and read few unnecessary keys at the boundary.
 - Todo: Pros and cons of both the approaches would be looked at later.
 - Focusing on implementing prefix approach for now as it is more inline with the current architecture.
@@ -72,13 +78,12 @@
     - Example one starting point for estimation could be: no. of rows in the table, and average cardinality for each column. Example: WHERE city = 'NYC'. estimated rows ==> 1k, avg column cardinality ==> 20 (20 distinct cities). estimated value of count of rows returned ==> 1k / 20 ==> 50.
     - Above is just a starting point to understand the concept. The above solution assumes uniform distribution (every city appears equally often).
 - **Role of histogram:** 
-    - A histogram breaks down the value range into buckets. Key --> value range, Value --> row count in that value range or bucket. age --> 
+    - A histogram breaks down the value range into buckets. Key --> value range, Value --> row count in that value range or bucket. age range --> count of rows in that age range.
     - [0 - 20] - 100 rows
     - [21 - 40] - 200 rows
     - [41 - 60] - 150 rows
     - age > 20 ==> sum last 2 buckets.
-    - age >= 18 ==> do some estimations --> last 2 buckets + (2 / 20) of first bucket
-
+    - age >= 18 ==> do some estimations --> last 2 buckets + (2 / 20) of first bucket.
 ## Plan Order
 Suggested order:
   1. Full-table scan (prefix approach) — unblocks everything else

--- a/docs/journal/part_8_sql_v2.md
+++ b/docs/journal/part_8_sql_v2.md
@@ -34,3 +34,56 @@
     - Currently how we serialise data is such that we reserve 4 bytes for integer type while reading.
     - Alternately we can store an additional byte telling whether it is NULL or NOT NULL.
     - If it is null, we don't read the 4 bytes.
+
+## Handling non-primary key based queries (Full-table scans)
+- Before building the approach for full-table scan, lets take a step back and revise how the data is structured.
+- Each file is a mem-table snapshot of key-value pairs.
+- When we require doing a full-table scan, we need to go through each file. This is because the same key can be found in multiple files even after compaction and the latest file is the most up-to-date value for the same key.
+- Another critical point is that we also need to check for the in-memory memtable which is not yet written to the ss-table.
+- As of now, the memtable and ss-table functions are structured to GET a single key.
+- Both of them need to have a prefix-scan function. How will this be implemented?
+- **SS-Table Prefix Scan**
+    - Go from the newest file to the oldest file.
+    - For each file:
+        - Run a binary search on the index block to find the appropriate data block (Run a lower bound for `table_name:`).
+        - Few reads from the data block might be wasteful. This is because the data block binary search would be based on the lower bound.
+        - Note: We are applying binary search to find the appropriate data block but not applying binary search within the data block as of now. We should also apply binary search there.
+        - Once one data block is done, move to the other one. Stop checking in the current data block and move to next file if you encounter a key where prefix is not equal to `table_name` prefix.
+        - Keep on building each of the row (key, value pairs) in-memory in a map.
+        - If a key is already present in the map, don't update it as we are going through the newest file first. Similarly, we would go over the memtable first as that has the newest data.
+- **Memtable Prefix Scan** 
+    - We should be able to utilise the **AscendGreaterOrEqual** function of the google/btree package.
+    - Key here also would be `table_name:` and as soon as the prefix changes, we stop reading from the memtable.
+- **Open Questions**:
+    - Claude had highlighted in a session that certain databases use merge iterator which makes the time complexity O (N logK). Didn't understand it. Let's discuss if there are more performant ways of doing this.
+
+### Prefix approach vs Per-table SS-Table Instance
+- Creating a separate ss-table could be a little bit more performant as we would not be requiring to go through index block and read few unnecessary keys at the boundary.
+- Todo: Pros and cons of both the approaches would be looked at later.
+- Focusing on implementing prefix approach for now as it is more inline with the current architecture.
+    - Compaction isolation is one clear advanatge of per-table ss-table instance.
+- We can optimise later if needed.
+
+## Query planner
+- Query planner is going to be a very interesting thing to build. Estimate which direction would produce the most efficient result without actually executing the query.
+- There can be multiple access paths to execute a query. 
+    - How to return how many rows a query would return without actually estimating? Stats: But how does stats solve it?
+    - Apart from storing data in tables, we would also be storing table level stats in some table.
+    - Example one starting point for estimation could be: no. of rows in the table, and average cardinality for each column. Example: WHERE city = 'NYC'. estimated rows ==> 1k, avg column cardinality ==> 20 (20 distinct cities). estimated value of count of rows returned ==> 1k / 20 ==> 50.
+    - Above is just a starting point to understand the concept. The above solution assumes uniform distribution (every city appears equally often).
+- **Role of histogram:** 
+    - A histogram breaks down the value range into buckets. Key --> value range, Value --> row count in that value range or bucket. age --> 
+    - [0 - 20] - 100 rows
+    - [21 - 40] - 200 rows
+    - [41 - 60] - 150 rows
+    - age > 20 ==> sum last 2 buckets.
+    - age >= 18 ==> do some estimations --> last 2 buckets + (2 / 20) of first bucket
+
+## Plan Order
+Suggested order:
+  1. Full-table scan (prefix approach) — unblocks everything else
+  2. AND support — straightforward filter composition post-scan
+  3. Secondary indexes — most interesting design challenge, teaches index maintenance on writes
+  4. Range-based queries — needs index seek, connects back to storage layer
+  5. Query planner — only becomes meaningful once you have multiple access paths (full scan vs index scan) to choose between
+  6. Unique index, composite indexes, NULL support — refinements

--- a/docs/journal/part_8_sql_v2.md
+++ b/docs/journal/part_8_sql_v2.md
@@ -70,6 +70,10 @@
     - Compaction isolation is one clear advanatge of per-table ss-table instance.
 - We can optimise later if needed.
 
+### Todo
+- Need to look at failing tests
+- How to efficiently store CHAR(14) and fixed length CHAR? 
+
 ## Query planner
 - Query planner is going to be a very interesting thing to build. Estimate which direction would produce the most efficient result without actually executing the query.
 - There can be multiple access paths to execute a query. 

--- a/memtable/memtable.go
+++ b/memtable/memtable.go
@@ -1,6 +1,9 @@
 package memtable
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/google/btree"
 )
 
@@ -56,6 +59,24 @@ func (m *Memtable) Put(key, value string) {
 	} else {
 		m.size += (len(key) + len(value))
 	}
+}
+
+// given the prefix key of a table, FullTableScan returns the serialised key
+// and value for that table for all the relevant table rows in the memtable.
+func (m *Memtable) FullTableScan(prefixKey string) map[string]string {
+	fmt.Printf("prefixKey5555: %v\n", prefixKey)
+	tableMap := map[string]string{}
+	m.tree.AscendGreaterOrEqual(&Entry{Key: prefixKey}, func(item btree.Item) bool {
+		e := item.(*Entry)
+		key := e.Key
+		fmt.Printf("key4444: %v\n", key)
+		if !strings.HasPrefix(key, prefixKey) {
+			return false
+		}
+		tableMap[key] = e.Value
+		return true
+	})
+	return tableMap
 }
 
 func (m *Memtable) ShouldFlush() bool {

--- a/sstable/compaction.go
+++ b/sstable/compaction.go
@@ -5,7 +5,6 @@ package sstable
 import (
 	"log/slog"
 	"os"
-	"strings"
 )
 
 func (st *SsTable) ShouldRunCompaction() bool {
@@ -28,15 +27,17 @@ func (st *SsTable) buildCompactedMap(files []*os.File) (map[string]string, error
 		if err != nil {
 			return nil, err
 		}
-		entries := strings.Split(string(buf), "\n")
-		for _, payload := range entries {
-			cmds := strings.Split(payload, " ")
-			if len(cmds) < 2 {
-				// todo: this is a hack. needs to be fixed.
-				continue
+		for i := 0; i < len(buf); {
+			key, err := extractValueFromSsTable(buf, i)
+			if err != nil {
+				return nil, err
 			}
-			key := cmds[1]
-			value := cmds[2]
+			i += (4 + len(key))
+			value, err := extractValueFromSsTable(buf, i)
+			if err != nil {
+				return nil, err
+			}
+			i += (4 + len(value))
 			compactedMap[key] = value
 		}
 	}

--- a/sstable/compaction.go
+++ b/sstable/compaction.go
@@ -82,7 +82,7 @@ func (st *SsTable) RunCompaction() {
 	if err != nil {
 		slog.Error("COMPACTED_FILE_CREATE_FAILED", "error", err.Error())
 	}
-	compactedIndexBlock, err := st.writeToFile(compactedFile, iterator)
+	compactedIndexOffset, compactedIndexBlock, err := st.writeToFile(compactedFile, iterator)
 	if err != nil {
 		slog.Error("COMPACTED_FILE_WRITE_FAILED", "error", err.Error())
 	}
@@ -90,7 +90,7 @@ func (st *SsTable) RunCompaction() {
 	slog.Info("COMPACTED_FILE_WRITE_SUCCESSFUL", "file_name", compactedFile.Name())
 
 	// 6. atomic swap of files array and indexes array
-	st.atomicSwap(compactedFile, filesToCompact, compactedIndexBlock)
+	st.atomicSwap(compactedFile, filesToCompact, compactedIndexBlock, compactedIndexOffset)
 
 	slog.Info("COMPACTED_FILE_ATOMIC_SWAP_SUCCESSFUL", "files_to_compact_count", len(filesToCompact))
 
@@ -101,10 +101,11 @@ func (st *SsTable) RunCompaction() {
 	}
 }
 
-// takes the compacted file, old files array and current state of files array to construct the new
-// ssTables array and sets it.
+// takes the compacted file, old files array and current state of files array to construct the new ssTables array and sets it.
 // similar behaviour done for indexes array.
-func (st *SsTable) atomicSwap(compactedFile *os.File, oldFiles []*os.File, compactedIndexBlock []indexBlockEntry) {
+// the old files / index block / index offset will not be kept after atomic swap as those have now been compacted.
+// while the new files which were not part of compaction will get added.
+func (st *SsTable) atomicSwap(compactedFile *os.File, oldFiles []*os.File, compactedIndexBlock []indexBlockEntry, compactedIndexOffset int) {
 	st.mutex.Lock()
 	defer st.mutex.Unlock()
 
@@ -120,12 +121,13 @@ func (st *SsTable) atomicSwap(compactedFile *os.File, oldFiles []*os.File, compa
 	swappedFiles := []*os.File{compactedFile}
 	fileNames := []string{compactedFile.Name()}
 	swappedIndexBlocks := [][]indexBlockEntry{compactedIndexBlock}
+	swappedIndexOffsets := []int{compactedIndexOffset}
 
 	for i, file := range currentFiles {
 		if !oldFilesMap[file.Name()] {
 			swappedFiles = append(swappedFiles, file)
 			swappedIndexBlocks = append(swappedIndexBlocks, st.indexBlocks[i])
-			// todo: update indexOffset also
+			swappedIndexOffsets = append(swappedIndexOffsets, st.indexOffsets[i])
 			fileNames = append(fileNames, file.Name())
 		}
 	}

--- a/sstable/compaction.go
+++ b/sstable/compaction.go
@@ -125,6 +125,7 @@ func (st *SsTable) atomicSwap(compactedFile *os.File, oldFiles []*os.File, compa
 		if !oldFilesMap[file.Name()] {
 			swappedFiles = append(swappedFiles, file)
 			swappedIndexBlocks = append(swappedIndexBlocks, st.indexBlocks[i])
+			// todo: update indexOffset also
 			fileNames = append(fileNames, file.Name())
 		}
 	}

--- a/sstable/sstable.go
+++ b/sstable/sstable.go
@@ -20,17 +20,19 @@ const (
 	manifestJsonFileName         = "manifest.json"
 )
 
+// index block entry specifies a single entry in the index block.
 type indexBlockEntry struct {
-	key    string
-	offset int
+	key    string // first key of the data block
+	offset int    // start of the data block
 }
 
 type SsTable struct {
 	mutex              sync.RWMutex
 	dataFilesDirectory string
 	firstLevelFiles    []*os.File
+	indexOffsets       []int // tracks the index block start offsets for each file
 	blockLength        int
-	indexBlocks        [][]indexBlockEntry
+	indexBlocks        [][]indexBlockEntry // stores the index block array for each file.
 	manifest           manifest
 	skipIndex          bool // added only for benchmarking. Default is that index will always be used
 	compacting         bool
@@ -56,6 +58,7 @@ func NewSsTable(config Config) (*SsTable, error) {
 		firstLevelFiles:    make([]*os.File, 0),
 		indexBlocks:        make([][]indexBlockEntry, 0),
 		mutex:              sync.RWMutex{},
+		indexOffsets:       make([]int, 0),
 	}
 
 	directoryMetadata, err := st.getDirectoryMetadata()
@@ -68,7 +71,7 @@ func NewSsTable(config Config) (*SsTable, error) {
 	if st.skipIndex {
 		return &st, err
 	}
-	indexBlocks, err := st.buildIndexes(st.firstLevelFiles)
+	indexBlocks, indexOffsets, err := st.buildIndexes(st.firstLevelFiles)
 	st.indexBlocks = indexBlocks
 	return &st, err
 }
@@ -233,16 +236,21 @@ func (st *SsTable) getDirectoryMetadata() (directoryMetadata *SsTable, err error
 	return directoryMetadata, nil
 }
 
-func (st *SsTable) buildIndexes(files []*os.File) ([][]indexBlockEntry, error) {
+// builds all of the indexes from the ss-table files.
+// returns: array of indexOffsets and array of indexBlock.
+// an indexBlock is denoted by an array of indexBlockEntry.
+func (st *SsTable) buildIndexes(files []*os.File) ([]int, [][]indexBlockEntry, error) {
 	ssTableIndexes := [][]indexBlockEntry{}
+	indexOffsets := []int{}
 	for _, file := range files {
-		ssTableIndex, err := st.buildIndexFromFile(file)
+		indexOffset, ssTableIndex, err := st.buildIndexFromFile(file)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		ssTableIndexes = append(ssTableIndexes, ssTableIndex)
+		indexOffsets = append(indexOffsets, indexOffset)
 	}
-	return ssTableIndexes, nil
+	return indexOffsets, ssTableIndexes, nil
 }
 
 func (st *SsTable) getIndexOffset(file *os.File) (uint32, error) {
@@ -256,24 +264,27 @@ func (st *SsTable) getIndexOffset(file *os.File) (uint32, error) {
 	return binary.BigEndian.Uint32(indexOffsetBuf), nil
 }
 
-func (st *SsTable) buildIndexFromFile(file *os.File) ([]indexBlockEntry, error) {
+// reads the index block from file and populates it in-memory.
+// stores both the index offset and the entire index block in-memory.
+func (st *SsTable) buildIndexFromFile(file *os.File) (int, []indexBlockEntry, error) {
 	// 1. get the index offset
 	info, err := os.Stat(file.Name())
 	if err != nil {
-		return nil, err
+		return 0, nil, err
 	}
 	fileSize := info.Size()
 	indexOffset, err := st.getIndexOffset(file)
 	if err != nil {
-		return nil, err
+		return 0, nil, err
 	}
+	// todo: store index offset in-memory
 
 	// 2. load index in-memory
 	// 2.1 read index byte array
 	indexBlockLength := (fileSize - 4) - int64(indexOffset)
 	indexBlockBuf := make([]byte, indexBlockLength)
 	if _, err = file.ReadAt(indexBlockBuf, int64(indexOffset)); err != nil {
-		return nil, err
+		return 0, nil, err
 	}
 
 	// 2.2 read keys and offsets from the index block and create in-memory index
@@ -286,14 +297,14 @@ func (st *SsTable) buildIndexFromFile(file *os.File) ([]indexBlockEntry, error) 
 		// read next keyLength bytes
 		i += 4
 		if i >= int(indexBlockLength) {
-			return nil, errors.New(errWhileReadingIndexBlock + ": " + potentialIndexBlockCorrupted)
+			return 0, nil, errors.New(errWhileReadingIndexBlock + ": " + potentialIndexBlockCorrupted)
 		}
 		key := string(indexBlockBuf[i : i+int(keyLength)])
 
 		// read offset
 		i += int(keyLength)
 		if i >= int(indexBlockLength) {
-			return nil, errors.New(errWhileReadingIndexBlock + ": " + potentialIndexBlockCorrupted)
+			return 0, nil, errors.New(errWhileReadingIndexBlock + ": " + potentialIndexBlockCorrupted)
 		}
 		offsetBuf := indexBlockBuf[i : i+4]
 		offset := binary.BigEndian.Uint32(offsetBuf)
@@ -301,7 +312,7 @@ func (st *SsTable) buildIndexFromFile(file *os.File) ([]indexBlockEntry, error) 
 		ssTableIndex = append(ssTableIndex, indexBlockEntry{key: key, offset: int(offset)})
 		i += 4
 	}
-	return ssTableIndex, nil
+	return int(indexOffset), ssTableIndex, nil
 }
 
 func (st *SsTable) Get(key string) (string, error) {
@@ -334,6 +345,62 @@ func (st *SsTable) Get(key string) (string, error) {
 	return "", nil
 }
 
+// return a map of the full table
+func (st *SsTable) FullTableScan(tableKey string) (map[string]string, error) {
+	st.mutex.RLock()
+	defer st.mutex.RUnlock()
+	tableMap := map[string]string{}
+	// newest file to oldest file
+	for i := len(st.firstLevelFiles) - 1; i >= 0; i-- {
+		file := st.firstLevelFiles[i]
+		ssTableIndex := st.indexBlocks[i]
+		lowerBoundSliceIndex := getLowerBound(tableKey, ssTableIndex)
+		if lowerBoundSliceIndex == -1 {
+			continue
+		}
+		// endOffset would be the start of index block
+		endOffset := st.indexOffsets[i]
+
+		err := st.sequentiallyScanTableAndUpdateMap(file, tableKey,
+			ssTableIndex[lowerBoundSliceIndex].offset, endOffset, tableMap)
+		return nil, err
+	}
+	return tableMap, nil
+}
+
+func (st *SsTable) sequentiallyScanTableAndUpdateMap(ssTableFile *os.File, tableKey string,
+	dataBlockStartOffset, fileEndOffset int, tableMap map[string]string) error {
+	ssTableDataBlockBuf := make([]byte, fileEndOffset-dataBlockStartOffset+1)
+	_, err := ssTableFile.ReadAt(ssTableDataBlockBuf, int64(dataBlockStartOffset))
+	if err != nil && err != io.EOF {
+		return err
+	}
+	ssTableDataBlockEntries := strings.Split(string(ssTableDataBlockBuf), "\n")
+	for _, payload := range ssTableDataBlockEntries {
+		// todo: this is a bug for non PUT commands like transaction and DELETE
+		// functionality to be added later.
+		cmds := strings.Split(payload, " ")
+		if len(cmds) != 3 {
+			continue
+		}
+		key := cmds[1]
+		value := cmds[2]
+		if strings.HasPrefix(key, tableKey) {
+			// only set the key value pair if the key is not found
+			// this is because we are sequentially going through the newest file first
+			if _, ok := tableMap[key]; !ok {
+				tableMap[key] = value
+			}
+		} else {
+			keyPrefix := key[0:min(len(tableKey), len(key))]
+			if keyPrefix > tableKey {
+				continue
+			}
+		}
+	}
+	return nil
+}
+
 func (st *SsTable) getValueFromSsTableDataBlock(ssTableFile *os.File, key string, dataBlockStartOffset, dataBlockEndOffset int) (string, error) {
 	ssTableDataBlockBuf := make([]byte, dataBlockEndOffset-dataBlockStartOffset+1)
 	_, err := ssTableFile.ReadAt(ssTableDataBlockBuf, int64(dataBlockStartOffset))
@@ -342,6 +409,8 @@ func (st *SsTable) getValueFromSsTableDataBlock(ssTableFile *os.File, key string
 	}
 	ssTableDataBlockEntries := strings.Split(string(ssTableDataBlockBuf), "\n")
 	for _, payload := range ssTableDataBlockEntries {
+		// todo: this is a bug for non PUT commands like transaction and DELETE
+		// functionality to be added later.
 		cmds := strings.Split(payload, " ")
 		if len(cmds) < 2 {
 			continue

--- a/sstable/sstable.go
+++ b/sstable/sstable.go
@@ -71,8 +71,9 @@ func NewSsTable(config Config) (*SsTable, error) {
 	if st.skipIndex {
 		return &st, err
 	}
-	indexBlocks, indexOffsets, err := st.buildIndexes(st.firstLevelFiles)
+	indexOffsets, indexBlocks, err := st.buildIndexes(st.firstLevelFiles)
 	st.indexBlocks = indexBlocks
+	st.indexOffsets = indexOffsets
 	return &st, err
 }
 
@@ -93,9 +94,9 @@ func (st *SsTable) NewFile() (*os.File, error) {
 // of SSTable file which is [data-block(s)][index-block][footer].
 // It calls the iteratorFunc function to get a stream of key, value pairs from a source.
 // example: 1. MemTable OR 2. firstLevelFiles which need to be merged and compacted.
-// It also updates the internal structs for firstLevelFiles and indexBlocks
+// It also updates the internal structs for firstLevelFiles, indexBlocks, manifest files and indexOffsets
 func (st *SsTable) Write(file *os.File, iteratorFunc func(fn func(key, value string))) error {
-	indexBlock, err := st.writeToFile(file, iteratorFunc)
+	indexOffset, indexBlock, err := st.writeToFile(file, iteratorFunc)
 	if err != nil {
 		return err
 	}
@@ -106,6 +107,7 @@ func (st *SsTable) Write(file *os.File, iteratorFunc func(fn func(key, value str
 		st.indexBlocks = append(st.indexBlocks, indexBlock)
 	}
 	st.manifest.FileNames = append(st.manifest.FileNames, file.Name())
+	st.indexOffsets = append(st.indexOffsets, indexOffset)
 
 	st.saveManifest()
 	st.mutex.Unlock()
@@ -117,20 +119,21 @@ func (st *SsTable) Write(file *os.File, iteratorFunc func(fn func(key, value str
 // of SSTable file which is [data-block(s)][index-block][footer].
 // It calls the iteratorFunc function to get a stream of key, value pairs from a source.
 // example: 1. MemTable OR 2. firstLevelFiles which need to be merged and compacted.
-func (st *SsTable) writeToFile(file *os.File, iteratorFunc func(fn func(key, value string))) ([]indexBlockEntry, error) {
+// returns the index block and indexOffset after writing to file.
+func (st *SsTable) writeToFile(file *os.File, iteratorFunc func(fn func(key, value string))) (int, []indexBlockEntry, error) {
 	indexOffset, indexBlock, err := st.writeDataBlocks(file, iteratorFunc)
 	if err != nil {
-		return nil, err
+		return 0, nil, err
 	}
 	if !st.skipIndex {
 		if err = st.writeIndexBlock(file, indexBlock); err != nil {
-			return nil, err
+			return 0, nil, err
 		}
 		if err = st.writeFooter(file, indexOffset); err != nil {
-			return nil, err
+			return 0, nil, err
 		}
 	}
-	return indexBlock, err
+	return indexOffset, indexBlock, err
 }
 
 func (st *SsTable) writeFooter(file *os.File, indexBlockStartOffset int) error {
@@ -329,10 +332,8 @@ func (st *SsTable) Get(key string) (string, error) {
 		if lowerBoundSliceIndex == -1 {
 			continue
 		}
-		endOffset := ssTableIndex[lowerBoundSliceIndex].offset + st.blockLength
+		endOffset := st.indexOffsets[i]
 		if lowerBoundSliceIndex < len(ssTableIndex)-1 {
-			// todo: it is safer to have endOffset as start of index offset.
-			// this can potentially lead to issue as more than
 			endOffset = ssTableIndex[lowerBoundSliceIndex+1].offset
 		}
 		value, err := st.getValueFromSsTableDataBlock(file, key,
@@ -361,19 +362,22 @@ func (st *SsTable) FullTableScan(tableKey string) (map[string]string, error) {
 		// endOffset would be the start of index block
 		endOffset := st.indexOffsets[i]
 
-		err := st.sequentiallyScanTableAndUpdateMap(file, tableKey,
+		var err error
+		tableMap, err = st.sequentiallyScanTableAndUpdateMap(file, tableKey,
 			ssTableIndex[lowerBoundSliceIndex].offset, endOffset, tableMap)
-		return nil, err
+		if err != nil {
+			return nil, err
+		}
 	}
 	return tableMap, nil
 }
 
 func (st *SsTable) sequentiallyScanTableAndUpdateMap(ssTableFile *os.File, tableKey string,
-	dataBlockStartOffset, fileEndOffset int, tableMap map[string]string) error {
+	dataBlockStartOffset, fileEndOffset int, tableMap map[string]string) (map[string]string, error) {
 	ssTableDataBlockBuf := make([]byte, fileEndOffset-dataBlockStartOffset+1)
 	_, err := ssTableFile.ReadAt(ssTableDataBlockBuf, int64(dataBlockStartOffset))
 	if err != nil && err != io.EOF {
-		return err
+		return nil, err
 	}
 	ssTableDataBlockEntries := strings.Split(string(ssTableDataBlockBuf), "\n")
 	for _, payload := range ssTableDataBlockEntries {
@@ -385,10 +389,13 @@ func (st *SsTable) sequentiallyScanTableAndUpdateMap(ssTableFile *os.File, table
 		}
 		key := cmds[1]
 		value := cmds[2]
+		fmt.Printf("key3333: %+v\n", key)
+		fmt.Printf("value3333: %+v\n", value)
 		if strings.HasPrefix(key, tableKey) {
 			// only set the key value pair if the key is not found
 			// this is because we are sequentially going through the newest file first
-			if _, ok := tableMap[key]; !ok {
+			if _, ok := (tableMap[key]); !ok {
+				fmt.Printf("REACH_22222 %v %v\n", key, value)
 				tableMap[key] = value
 			}
 		} else {
@@ -398,7 +405,7 @@ func (st *SsTable) sequentiallyScanTableAndUpdateMap(ssTableFile *os.File, table
 			}
 		}
 	}
-	return nil
+	return tableMap, nil
 }
 
 func (st *SsTable) getValueFromSsTableDataBlock(ssTableFile *os.File, key string, dataBlockStartOffset, dataBlockEndOffset int) (string, error) {

--- a/sstable/sstable.go
+++ b/sstable/sstable.go
@@ -15,9 +15,10 @@ const (
 	firstLevelFilesSubdirectory = "l0"
 	defaultBlockLength          = 100
 
-	errWhileReadingIndexBlock    = "error while reading index block"
-	potentialIndexBlockCorrupted = "index block seems incomplete or corrupted"
-	manifestJsonFileName         = "manifest.json"
+	errWhileReadingIndexBlock         = "error while reading index block"
+	potentialIndexBlockCorrupted      = "index block seems incomplete or corrupted"
+	manifestJsonFileName              = "manifest.json"
+	errorWhileReadingSsTableDatablock = "error while reading ss-table data block"
 )
 
 // index block entry specifies a single entry in the index block.
@@ -153,7 +154,7 @@ func (st *SsTable) writeDataBlocks(file *os.File, iteratorFunc func(fn func(key,
 	blockLength := 0
 	blockStartOffset := 0
 	blockFirstKey := ""
-	ssTableBlock := ""
+	ssTableBlockBuf := []byte{}
 	offset := 0
 	indexBlock := []indexBlockEntry{}
 
@@ -163,10 +164,17 @@ func (st *SsTable) writeDataBlocks(file *os.File, iteratorFunc func(fn func(key,
 		if blockFirstKey == "" {
 			blockFirstKey = key
 		}
-		ssTableEntry := fmt.Sprintf("PUT %s %s\n", key, value)
-		offset += len(ssTableEntry)
-		blockLength += len(ssTableEntry)
-		ssTableBlock = ssTableBlock + ssTableEntry
+		// write byte array
+		// todo: checksum to be added later
+		// [length_of_key][key][length_of_value][value]
+		ssTableEntryBuf := []byte{}
+		ssTableEntryBuf = binary.BigEndian.AppendUint32(ssTableEntryBuf, uint32(len(key)))
+		ssTableEntryBuf = append(ssTableEntryBuf, []byte(key)...)
+		ssTableEntryBuf = binary.BigEndian.AppendUint32(ssTableEntryBuf, uint32(len(value)))
+		ssTableEntryBuf = append(ssTableEntryBuf, []byte(value)...)
+		offset += len(ssTableEntryBuf)
+		blockLength += len(ssTableEntryBuf)
+		ssTableBlockBuf = append(ssTableBlockBuf, ssTableEntryBuf...)
 		if blockLength > st.blockLength {
 			// one data block completed
 
@@ -178,7 +186,7 @@ func (st *SsTable) writeDataBlocks(file *os.File, iteratorFunc func(fn func(key,
 			// write this data block to the file
 			// todo: change data block entry to [length][payload][checksum]
 			// instead of "PUT key value\n"
-			if _, err = file.Write([]byte(ssTableBlock)); err != nil {
+			if _, err = file.Write(ssTableBlockBuf); err != nil {
 				// todo: add some break statement
 				// break
 			}
@@ -187,7 +195,7 @@ func (st *SsTable) writeDataBlocks(file *os.File, iteratorFunc func(fn func(key,
 			blockStartOffset = offset
 			blockFirstKey = ""
 			blockLength = 0
-			ssTableBlock = ""
+			ssTableBlockBuf = []byte{}
 		}
 	})
 
@@ -197,7 +205,7 @@ func (st *SsTable) writeDataBlocks(file *os.File, iteratorFunc func(fn func(key,
 			key:    blockFirstKey,
 			offset: blockStartOffset,
 		})
-		_, err = file.Write([]byte(ssTableBlock))
+		_, err = file.Write(ssTableBlockBuf)
 	}
 	return offset, indexBlock, err
 }
@@ -378,23 +386,37 @@ func (st *SsTable) FullTableScan(tableKey string) (map[string]string, error) {
 	return tableMap, nil
 }
 
+func extractValueFromSsTable(ssTableDataBlockBuf []byte, i int) (string, error) {
+	if i+4 > len(ssTableDataBlockBuf) {
+		return "", errors.New(errorWhileReadingSsTableDatablock)
+	}
+	keyLen := binary.BigEndian.Uint32(ssTableDataBlockBuf[i : i+4])
+	i += 4
+	if i+int(keyLen) > len(ssTableDataBlockBuf) {
+		return "", errors.New(errorWhileReadingSsTableDatablock)
+	}
+	return string(ssTableDataBlockBuf[i : i+int(keyLen)]), nil
+}
+
 func (st *SsTable) sequentiallyScanTableAndUpdateMap(ssTableFile *os.File, tableKey string,
 	dataBlockStartOffset, fileEndOffset int, tableMap map[string]string) (map[string]string, error) {
-	ssTableDataBlockBuf := make([]byte, fileEndOffset-dataBlockStartOffset+1)
+	ssTableDataBlockBuf := make([]byte, fileEndOffset-dataBlockStartOffset)
 	_, err := ssTableFile.ReadAt(ssTableDataBlockBuf, int64(dataBlockStartOffset))
 	if err != nil && err != io.EOF {
 		return nil, err
 	}
-	ssTableDataBlockEntries := strings.Split(string(ssTableDataBlockBuf), "\n")
-	for _, payload := range ssTableDataBlockEntries {
-		// todo: this is a bug for non PUT commands like transaction and DELETE
-		// functionality to be added later.
-		cmds := strings.Split(payload, " ")
-		if len(cmds) != 3 {
-			continue
+	for i := 0; i < len(ssTableDataBlockBuf); {
+		key, err := extractValueFromSsTable(ssTableDataBlockBuf, i)
+		if err != nil {
+			return nil, err
 		}
-		key := cmds[1]
-		value := cmds[2]
+		i += (4 + len(key))
+		value, err := extractValueFromSsTable(ssTableDataBlockBuf, i)
+		if err != nil {
+			return nil, err
+		}
+		i += (4 + len(value))
+
 		fmt.Printf("key3333: %+v\n", key)
 		fmt.Printf("value3333: %+v\n", value)
 		if strings.HasPrefix(key, tableKey) {
@@ -407,7 +429,7 @@ func (st *SsTable) sequentiallyScanTableAndUpdateMap(ssTableFile *os.File, table
 		} else {
 			keyPrefix := key[0:min(len(tableKey), len(key))]
 			if keyPrefix > tableKey {
-				continue
+				return tableMap, nil
 			}
 		}
 	}
@@ -422,8 +444,6 @@ func (st *SsTable) getValueFromSsTableDataBlock(ssTableFile *os.File, key string
 	}
 	ssTableDataBlockEntries := strings.Split(string(ssTableDataBlockBuf), "\n")
 	for _, payload := range ssTableDataBlockEntries {
-		// todo: this is a bug for non PUT commands like transaction and DELETE
-		// functionality to be added later.
 		cmds := strings.Split(payload, " ")
 		if len(cmds) < 2 {
 			continue

--- a/sstable/sstable.go
+++ b/sstable/sstable.go
@@ -442,14 +442,19 @@ func (st *SsTable) getValueFromSsTableDataBlock(ssTableFile *os.File, key string
 	if err != nil && err != io.EOF {
 		return "", err
 	}
-	ssTableDataBlockEntries := strings.Split(string(ssTableDataBlockBuf), "\n")
-	for _, payload := range ssTableDataBlockEntries {
-		cmds := strings.Split(payload, " ")
-		if len(cmds) < 2 {
-			continue
+	for i := 0; i < len(ssTableDataBlockBuf); {
+		currentKey, err := extractValueFromSsTable(ssTableDataBlockBuf, i)
+		if err != nil {
+			return "", err
 		}
-		if cmds[1] == key {
-			return cmds[2], nil
+		i += (4 + len(currentKey))
+		currentValue, err := extractValueFromSsTable(ssTableDataBlockBuf, i)
+		if err != nil {
+			return "", err
+		}
+		i += (4 + len(currentValue))
+		if currentKey == key {
+			return currentValue, nil
 		}
 	}
 	return "", nil

--- a/sstable/sstable.go
+++ b/sstable/sstable.go
@@ -176,7 +176,7 @@ func (st *SsTable) writeDataBlocks(file *os.File, iteratorFunc func(fn func(key,
 			})
 
 			// write this data block to the file
-			// todo: change data block entry to [length][payload][checksum]xx
+			// todo: change data block entry to [length][payload][checksum]
 			// instead of "PUT key value\n"
 			if _, err = file.Write([]byte(ssTableBlock)); err != nil {
 				// todo: add some break statement
@@ -356,8 +356,14 @@ func (st *SsTable) FullTableScan(tableKey string) (map[string]string, error) {
 		file := st.firstLevelFiles[i]
 		ssTableIndex := st.indexBlocks[i]
 		lowerBoundSliceIndex := getLowerBound(tableKey, ssTableIndex)
+		// means that even the first key prefix >= prefix in tableKey
 		if lowerBoundSliceIndex == -1 {
-			continue
+			// if prefix doesn't match for the first key, no need to read this file
+			if len(ssTableIndex) == 0 || !strings.HasPrefix(ssTableIndex[0].key, tableKey) {
+				continue
+			}
+			// if prefix matches, we need to read the entire file till we encounter a different prefix
+			lowerBoundSliceIndex = 0
 		}
 		// endOffset would be the start of index block
 		endOffset := st.indexOffsets[i]


### PR DESCRIPTION
1. Refactored the code to move SELECT query related functions to a separate file.
2. Implemented full-table scan at 2 layers: memtable and sstable.
3. Priority logic in case of conflicting key: memtable > newest sstable file > .... oldest sstable file.
4. Utilised AscendGreaterOrEqual provided by google/btree for memtable prefix scan for full-table scan.
5. Ss-table implementation for full-table scan. Started storing index-offset in-memory for faster read from lower bound till the end of the file.
6. Fix: Deserialisation was failing during full-table scan reads due to serialised keys conflict with spaces and \n. Moved the logic to binary serialisation and deserialisation: length and payload based ([key_len][key][value_len][value]).
7. Todo: need to fix breaking changes which might have resulted from some recent change leading to few critical older tests failing.