### PR TITLE
Bugfix + In-memory filter + Secondary Index Benchmark 

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -334,6 +334,8 @@ func getSecondaryIndexKeyOrPrefix(tableName, indexName string, columnValues []st
 	indexKey += indexColValues
 	if primaryKeyValue != "" {
 		indexKey += (":" + primaryKeyValue)
+	} else {
+		indexKey += ":"
 	}
 	return indexKey
 }

--- a/db/secondary_index_perf_test.go
+++ b/db/secondary_index_perf_test.go
@@ -1,0 +1,114 @@
+//go:build secondaryindex
+// +build secondaryindex
+
+package db
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"os"
+	"testing"
+
+	sqlparser "github.com/golang-db/sql_parser"
+	"github.com/golang-db/sstable"
+	"github.com/stretchr/testify/assert"
+)
+
+func newDBForTestForDir(dirNum int) (*DB, func(), error) {
+	walFilePath := fmt.Sprintf("temp_wal_%d.log", dirNum)
+	dataFilesDirectory := fmt.Sprintf("temp_%d", dirNum)
+	dbInstance, err := NewDB(Config{
+		SsTableConfig: sstable.Config{
+			DataFilesDirectory: dataFilesDirectory,
+		},
+		WalFilePath: walFilePath,
+	})
+	cleanupFunc := func() {
+		defer os.RemoveAll(dataFilesDirectory)
+		defer os.Remove(walFilePath)
+	}
+	return dbInstance, cleanupFunc, err
+}
+
+// returns all possible unique values present in column c2
+func (db *DB) insertTestData(t assert.TestingT, lowCardinality bool, rowsCount int) {
+	for i := 0; i < rowsCount; i++ {
+		c2Value := rand.IntN(10)
+		if !lowCardinality {
+			c2Value = rand.IntN(rowsCount / 2)
+		}
+		err := db.insertIntoTable(sqlparser.InsertIntoTable{
+			TableName: "t1",
+			ColumnValues: []string{
+				fmt.Sprintf("pk_%d", i),
+				fmt.Sprintf("%d", c2Value),
+				fmt.Sprintf("%d", i%5),
+				fmt.Sprintf("%d", i%2),
+			},
+		})
+		assert.NoError(t, err)
+	}
+}
+
+func benchmarkSecondaryIndexPerformance(b *testing.B, useIndex bool, lowCardinality bool, rowsCount, dirNum int) {
+	dbInstance, cleanupFunc, err := newDBForTestForDir(dirNum)
+	assert.NoError(b, err)
+	defer cleanupFunc()
+
+	_, _, err = createTestTable(dbInstance, useIndex)
+	assert.NoError(b, err)
+
+	dbInstance.insertTestData(b, lowCardinality, rowsCount)
+	for b.Loop() {
+		actualRowsCount := 0
+		valuesRange := 10
+		if !lowCardinality {
+			valuesRange = rowsCount / 2
+		}
+		for i := 0; i < valuesRange; i++ {
+			queryRes, err := dbInstance.selectFromTable(sqlparser.SelectFromTable{
+				TableName: "t1",
+				QueryConditions: []sqlparser.QueryCondition{{
+					ColumnName: "c2",
+					QueryType:  sqlparser.Equals,
+					Value:      fmt.Sprintf("%d", i),
+				}},
+			})
+			assert.NoError(b, err)
+			actualRowsCount += len(queryRes)
+		}
+		assert.Equal(b, rowsCount, actualRowsCount)
+	}
+}
+
+func BenchmarkSecondaryIndex_NotUsedLowCardinality100Rows(b *testing.B) {
+	benchmarkSecondaryIndexPerformance(b, false, true, 100, 0)
+}
+
+func BenchmarkSecondaryIndex_UsedLowCardinality100Rows(b *testing.B) {
+	benchmarkSecondaryIndexPerformance(b, true, true, 100, 1)
+}
+
+func BenchmarkSecondaryIndex_NotUsedHighCardinality100Rows(b *testing.B) {
+	benchmarkSecondaryIndexPerformance(b, false, false, 100, 2)
+}
+
+func BenchmarkSecondaryIndex_UsedHighCardinality100Rows(b *testing.B) {
+	benchmarkSecondaryIndexPerformance(b, true, false, 100, 3)
+}
+
+func BenchmarkSecondaryIndex_NotUsedLowCardinality10kRows(b *testing.B) {
+	benchmarkSecondaryIndexPerformance(b, false, true, 10000, 4)
+}
+
+func BenchmarkSecondaryIndex_UsedLowCardinality10kRows(b *testing.B) {
+	benchmarkSecondaryIndexPerformance(b, true, true, 10000, 5)
+}
+
+func BenchmarkSecondaryIndex_NotUsedHighCardinality10kRows(b *testing.B) {
+	benchmarkSecondaryIndexPerformance(b, false, false, 10000, 6)
+}
+
+func BenchmarkSecondaryIndex_UsedHighCardinality10kRows(b *testing.B) {
+	benchmarkSecondaryIndexPerformance(b, true, false, 10000, 7)
+}

--- a/db/secondary_index_test.go
+++ b/db/secondary_index_test.go
@@ -8,10 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSecondaryIndexBasedQueries(t *testing.T) {
-	dbInstance, cleanupFunc, err := newDBForTest()
-	defer cleanupFunc()
-
+func createTestTable(dbInstance *DB, createIndexOnC2 bool) ([]sqlparser.Column, []sqlparser.SecondaryIndex, error) {
 	colDetails := []sqlparser.Column{
 		{
 			ColumnName: "c1",
@@ -37,21 +34,32 @@ func TestSecondaryIndexBasedQueries(t *testing.T) {
 			IndexName: "idxc1",
 		},
 		{
-			Columns:   []string{"c2"},
-			IndexName: "idxc2",
-		},
-		{
 			Columns:   []string{"c3", "c4"},
 			IndexName: "idxc3c4",
 		},
 		// todo: try with incorrect column name as well
 	}
 
-	err = dbInstance.createTable(sqlparser.CreateTable{
+	if createIndexOnC2 {
+		secondaryIndexes = append(secondaryIndexes, sqlparser.SecondaryIndex{
+			Columns:   []string{"c2"},
+			IndexName: "idxc2"})
+	}
+
+	err := dbInstance.createTable(sqlparser.CreateTable{
 		TableName:        "t1",
 		ColumnDetails:    colDetails,
 		SecondaryIndexes: secondaryIndexes,
 	})
+
+	return colDetails, secondaryIndexes, err
+}
+
+func TestSecondaryIndexBasedQueries(t *testing.T) {
+	dbInstance, cleanupFunc, err := newDBForTest()
+	defer cleanupFunc()
+
+	colDetails, secondaryIndexes, err := createTestTable(dbInstance, true)
 	assert.NoError(t, err)
 	t1Schema := dbInstance.tableNameVsSchemaMap["t1"]
 	assert.Equal(t, secondaryIndexes, t1Schema.SecondaryIndexes)
@@ -151,7 +159,7 @@ func TestSecondaryIndexBasedQueries(t *testing.T) {
 
 	// part 4: test the result for c4: no index exists
 	for i := 0; i < 2; i++ {
-		_, err := dbInstance2.selectFromTable(sqlparser.SelectFromTable{
+		queryResult, err := dbInstance2.selectFromTable(sqlparser.SelectFromTable{
 			TableName: "t1",
 			QueryConditions: []sqlparser.QueryCondition{
 				{
@@ -161,12 +169,28 @@ func TestSecondaryIndexBasedQueries(t *testing.T) {
 				},
 			},
 		})
-		assert.Equal(t, "query not supported", err.Error())
+		expectedList := [][]string{
+			{"val1_0", "val2_0", "0", "0"},
+			{"val1_2", "val2_2", "2", "0"},
+			{"val1_4", "val2_4", "4", "0"},
+			{"val1_6", "val2_6", "1", "0"},
+			{"val1_8", "val2_8", "3", "0"},
+		}
+		if i == 1 {
+			expectedList = [][]string{
+				{"val1_1", "val2_1", "1", "1"},
+				{"val1_3", "val2_3", "3", "1"},
+				{"val1_5", "val2_5", "0", "1"},
+				{"val1_7", "val2_7", "2", "1"},
+				{"val1_9", "val2_9", "4", "1"},
+			}
+		}
+		assert.ElementsMatch(t, expectedList, queryResult)
+		assert.NoError(t, err)
 	}
 
 	// todo: UTs for filters post index with less than, greater than conditions.
 	// todo: logic + UTs for filters via primary key and secondary index with less than, greater than conditions.
-	// todo: benchmarking for performance: with and without indexes.
 
 	// todo: as of now partial indexes are not supported.
 	// Check the result

--- a/db/select.go
+++ b/db/select.go
@@ -119,11 +119,20 @@ func (db *DB) filterQueryConditions(tableName string, queryConditions []sqlparse
 	return queryResult, nil
 }
 
+func (db *DB) runFullTableScanAndFilterConditions(tableName string, selectFromTableInput sqlparser.SelectFromTable) ([][]string, error) {
+	queryResult, err := db.fullTableScan(tableName)
+	if err != nil {
+		return nil, err
+	}
+	return db.filterQueryConditions(tableName, selectFromTableInput.QueryConditions,
+		[]string{}, queryResult)
+}
+
 // todo: not solving for RANGE queries within secondary index or primary key right now.
 func (db *DB) getQueryResultFromSecondaryIndexIfApplicable(tableName string, selectFromTableInput sqlparser.SelectFromTable, schema sqlparser.CreateTable) ([][]string, error) {
 	secondaryIndex, colsCoveredInSecIndex := getSecondaryIndexForQueryIfApplicable(selectFromTableInput, schema.SecondaryIndexes)
 	if secondaryIndex == nil {
-		return nil, errors.New("query not supported")
+		return db.runFullTableScanAndFilterConditions(tableName, selectFromTableInput)
 	}
 	columnValues := []string{}
 	for _, condition := range selectFromTableInput.QueryConditions {
@@ -180,7 +189,6 @@ func (db *DB) selectFromTable(selectFromTableInput sqlparser.SelectFromTable) ([
 		return db.fullTableScan(tableName)
 	}
 
-	// todo: not solving for AND queries right now. only using secondary index when all columns are covered
 	return db.getQueryResultFromSecondaryIndexIfApplicable(tableName, selectFromTableInput, schema)
 }
 
@@ -252,14 +260,21 @@ func (db *DB) secondaryIndexPrefixScan(prefixKey string) ([]string, error) {
 		return nil, err
 	}
 
+	pkSet := make(map[string]bool)
+
 	primaryKeyIds := []string{}
 	for key, _ := range ssTableMap {
 		keyElements := strings.Split(key, ":")
-		primaryKeyIds = append(primaryKeyIds, keyElements[len(keyElements)-1])
+		pk := keyElements[len(keyElements)-1]
+		pkSet[pk] = true
 	}
 	for key, _ := range memTableMap {
 		keyElements := strings.Split(key, ":")
-		primaryKeyIds = append(primaryKeyIds, keyElements[len(keyElements)-1])
+		pk := keyElements[len(keyElements)-1]
+		pkSet[pk] = true
+	}
+	for pk := range pkSet {
+		primaryKeyIds = append(primaryKeyIds, pk)
 	}
 	return primaryKeyIds, nil
 }

--- a/docs/benchmark_results/secondary_index.md
+++ b/docs/benchmark_results/secondary_index.md
@@ -1,0 +1,15 @@
+go test -bench=. -tags=secondaryindex -run=^$ -benchmem -p=1
+goos: darwin
+goarch: arm64
+pkg: github.com/golang-db/db
+cpu: Apple M1 Pro
+BenchmarkSecondaryIndex_NotUsedLowCardinality100Rows-8    	    7602	    153532 ns/op	  246742 B/op	    2296 allocs/op
+BenchmarkSecondaryIndex_UsedLowCardinality100Rows-8       	   20708	     53451 ns/op	   49075 B/op	     984 allocs/op
+BenchmarkSecondaryIndex_NotUsedHighCardinality100Rows-8   	    1453	    820046 ns/op	 1221214 B/op	   15508 allocs/op
+BenchmarkSecondaryIndex_UsedHighCardinality100Rows-8      	   14221	     80750 ns/op	   65225 B/op	    1751 allocs/op
+BenchmarkSecondaryIndex_NotUsedLowCardinality10kRows-8    	      52	  22126575 ns/op	30654487 B/op	  201180 allocs/op
+BenchmarkSecondaryIndex_UsedLowCardinality10kRows-8       	     136	   8549737 ns/op	 5974242 B/op	   70768 allocs/op
+BenchmarkSecondaryIndex_NotUsedHighCardinality10kRows-8   	       1	10927318625 ns/op	15402915488 B/op	150480054 allocs/op
+BenchmarkSecondaryIndex_UsedHighCardinality10kRows-8      	      97	  12100610 ns/op	 6693958 B/op	  182814 allocs/op
+PASS
+ok  	github.com/golang-db/db	196.224s

--- a/docs/journal/part_9_sql_v3.md
+++ b/docs/journal/part_9_sql_v3.md
@@ -1,0 +1,8 @@
+### Benchmarking Performance Of Secondary Indexes
+- Write multiple benchmarks: 100, 1k, 10k, 100k, 1 million rows inserted.
+- Only 2 columns: c1: PK, c2
+- What is the cardinality for c2? Test both cases 
+    - Low cardinality case: only 5-10 unique values.
+    - High cardinality case: Some random id set. 
+- Case 1: add index on c2.
+- Case 2: don't add index on c2.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/golang-db
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/google/btree v1.1.3


### PR DESCRIPTION
1. critical bugfix in secondary prefix scan logic. secondary index GET query was not having a : at the end leading to column values with 5 matching with 50, 51, ... as well. this bug was caught while writing UTs. 
2. code changes + UT to carry out filters in-memory even when index is not chosen. 
3. benchmark and tests for following cases: low cardinality, high cardinality, 100 rows and 10k rows.