### PR TITLE
Fix binary-safe WAL command payloads

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -20,6 +20,7 @@ const (
 	SecondaryIndexesCatalogKeyTemplate       = "_secondary_indexes:%s"
 	SchemaTemplate                           = "_schema:%s"
 	IndexKeyTemplateTableNameIndexNamePrefix = "index:%s:%s"
+	CmdPut                                   = "PUT"
 )
 
 type LocksAcquired struct {
@@ -169,28 +170,59 @@ func (db *DB) flushMemtableToSsTable() error {
 }
 
 func (db *DB) writeToWal(key, value string) error {
-	buf := serialiseCommand("PUT", fmt.Sprintf("PUT %s %s", key, value))
+	buf := serialisePutCommand(key, value)
 	return db.wal.WriteEntry(buf)
 }
 
-func serialiseCommand(command, payload string) []byte {
-	buf := []byte{}
-	buf = binary.BigEndian.AppendUint32(buf, uint32(len(command)))
-	buf = append(buf, []byte(command)...)
-	buf = binary.BigEndian.AppendUint32(buf, uint32(len(payload)))
-	buf = append(buf, []byte(payload)...)
+func appendLengthPrefixedString(buf []byte, value string) []byte {
+	buf = binary.BigEndian.AppendUint32(buf, uint32(len(value)))
+	buf = append(buf, []byte(value)...)
 	return buf
 }
 
-func handlePutCmd(memTable memtable.Memtable, line string) error {
-	args := strings.Split(line, " ")
-	if len(args) != 3 {
-		return errors.New("Expected exactly 2 arguments for PUT command")
+func readUint32(buf []byte, offset *int) (uint32, error) {
+	if len(buf)-*offset < 4 {
+		return 0, errors.New("malformed WAL command: missing uint32")
 	}
-	key := args[1]
-	value := args[2]
-	memTable.Put(key, value)
-	return nil
+	value := binary.BigEndian.Uint32(buf[*offset : *offset+4])
+	*offset += 4
+	return value, nil
+}
+
+func readLengthPrefixedString(buf []byte, offset *int) (string, error) {
+	valueLen, err := readUint32(buf, offset)
+	if err != nil {
+		return "", err
+	}
+	if valueLen > uint32(len(buf)-*offset) {
+		return "", errors.New("malformed WAL command: string length exceeds payload")
+	}
+	value := string(buf[*offset : *offset+int(valueLen)])
+	*offset += int(valueLen)
+	return value, nil
+}
+
+func serialisePutCommand(key, value string) []byte {
+	buf := []byte{}
+	buf = appendLengthPrefixedString(buf, CmdPut)
+	buf = appendLengthPrefixedString(buf, key)
+	buf = appendLengthPrefixedString(buf, value)
+	return buf
+}
+
+func deserialisePutCommand(buf []byte, offset *int) (key, value string, err error) {
+	key, err = readLengthPrefixedString(buf, offset)
+	if err != nil {
+		return "", "", err
+	}
+	value, err = readLengthPrefixedString(buf, offset)
+	if err != nil {
+		return "", "", err
+	}
+	if *offset != len(buf) {
+		return "", "", errors.New("malformed WAL command: unexpected trailing bytes")
+	}
+	return key, value, nil
 }
 
 func (db *DB) buildMemtableFromWal() (*memtable.Memtable, error) {
@@ -207,24 +239,28 @@ func (db *DB) buildMemtableFromWal() (*memtable.Memtable, error) {
 			return nil, err
 		}
 
-		// read [command_length(4_bytes)][command_string] to figure out the command type
-		// and accordingly deserialise.
-		i := 0
-		len := binary.BigEndian.Uint32(payload[i : i+4])
-		i += 4
-		cmd := string(payload[i : i+int(len)])
-		i += int(len)
-		if cmd == CmdTransaction {
-			putCmds := deserialiseTransactionCommand(payload[i:])
-			for _, cmd := range putCmds {
-				if err := handlePutCmd(memTable, cmd); err != nil {
-					return nil, err
-				}
-			}
-		} else {
-			if err := handlePutCmd(memTable, string(payload)); err != nil {
+		offset := 0
+		cmd, err := readLengthPrefixedString(payload, &offset)
+		if err != nil {
+			return nil, err
+		}
+		switch cmd {
+		case CmdPut:
+			key, value, err := deserialisePutCommand(payload, &offset)
+			if err != nil {
 				return nil, err
 			}
+			memTable.Put(key, value)
+		case CmdTransaction:
+			putCmds, err := deserialiseTransactionCommand(payload[offset:])
+			if err != nil {
+				return nil, err
+			}
+			for _, cmd := range putCmds {
+				memTable.Put(cmd.key, cmd.value)
+			}
+		default:
+			return nil, fmt.Errorf("unknown WAL command: %s", cmd)
 		}
 	}
 }

--- a/db/transaction.go
+++ b/db/transaction.go
@@ -19,6 +19,11 @@ type Transaction struct {
 	lockAcquiredKeys []string
 }
 
+type walPutCommand struct {
+	key   string
+	value string
+}
+
 func (txn *Transaction) tryAcquireWriteLock(key string) error {
 	locksAcquired, ok := txn.db.transactionManager.keyVsLocksAcquiredMap[key]
 	readLockAlreadyAcquired := false
@@ -155,58 +160,59 @@ func (txn *Transaction) Rollback() {
 	txn.cleanupBufferedWriteMap()
 }
 
-// structure: [length][payload][offset]
 // payload structure:
-// ----
-// [length_of_command][command][number_of_writes]
-// [payload_length_for_1st][payload_for_1st][payload_length_for_2nd][payload_for_2nd]...
-// till N = number_of_writes
-// ----
-// command is "TRANSACTION" in this case
-// todo: we need to change the structure of payload for PUT command also similar to this.
+// [length_of_command][command="TRANSACTION"][number_of_writes]
+// [key_length_for_1st][key_for_1st][value_length_for_1st][value_for_1st]...
 func serialiseTransactionCommitPayload(writeMap map[string]string) []byte {
-	payloads := []string{}
-	for key, value := range writeMap {
-		payload := fmt.Sprintf("PUT %s %s", key, value)
-		payloads = append(payloads, payload)
-	}
-
 	buf := []byte{}
-	transactionStr := "TRANSACTION"
-	buf = binary.BigEndian.AppendUint32(buf, uint32(len(transactionStr)))
-	buf = append(buf, []byte(transactionStr)...)
-	buf = binary.BigEndian.AppendUint32(buf, uint32(len(payloads)))
+	buf = appendLengthPrefixedString(buf, CmdTransaction)
+	buf = binary.BigEndian.AppendUint32(buf, uint32(len(writeMap)))
 
-	for _, payload := range payloads {
-		buf = binary.BigEndian.AppendUint32(buf, uint32(len(payload)))
-		buf = append(buf, []byte(payload)...)
+	for key, value := range writeMap {
+		buf = appendLengthPrefixedString(buf, key)
+		buf = appendLengthPrefixedString(buf, value)
 	}
 	return buf
 }
 
-// [number_of_writes][payload_length_for_1st][payload_for_1st][payload_length_for_2nd][payload_for_2nd]...
-func deserialiseTransactionCommand(buf []byte) (payloads []string) {
-	i := 0
-	numWrites := binary.BigEndian.Uint32(buf[i : i+4])
-	i += 4
-	for j := 0; j < int(numWrites); j++ {
-		payloadLength := binary.BigEndian.Uint32(buf[i : i+4])
-		i += 4
-		payload := string(buf[i : i+int(payloadLength)])
-		i += int(payloadLength)
-		payloads = append(payloads, payload)
+// [number_of_writes][key_length_for_1st][key_for_1st][value_length_for_1st][value_for_1st]...
+func deserialiseTransactionCommand(buf []byte) ([]walPutCommand, error) {
+	offset := 0
+	numWrites, err := readUint32(buf, &offset)
+	if err != nil {
+		return nil, err
 	}
-	return payloads
+	putCmds := []walPutCommand{}
+	for j := 0; j < int(numWrites); j++ {
+		key, err := readLengthPrefixedString(buf, &offset)
+		if err != nil {
+			return nil, err
+		}
+		value, err := readLengthPrefixedString(buf, &offset)
+		if err != nil {
+			return nil, err
+		}
+		putCmds = append(putCmds, walPutCommand{
+			key:   key,
+			value: value,
+		})
+	}
+	if offset != len(buf) {
+		return nil, errors.New("malformed WAL command: unexpected trailing bytes")
+	}
+	return putCmds, nil
 }
 
 // necessary to do in a single WAL write for atomicity
-func (txn *Transaction) writeSingleWalEntryForCommit() {
+func (txn *Transaction) writeSingleWalEntryForCommit() error {
 	buf := serialiseTransactionCommitPayload(txn.bufferedWriteMap)
-	txn.db.wal.WriteEntry(buf)
+	return txn.db.wal.WriteEntry(buf)
 }
 
 func (txn *Transaction) Commit() error {
-	txn.writeSingleWalEntryForCommit()
+	if err := txn.writeSingleWalEntryForCommit(); err != nil {
+		return err
+	}
 
 	// put in memtable done separately instead of db.Put as that would lead to separate writes in WAL
 	for key, value := range txn.bufferedWriteMap {

--- a/db/wal_command_test.go
+++ b/db/wal_command_test.go
@@ -25,6 +25,17 @@ func newDBForWalCommandTest(t *testing.T) (*DB, Config) {
 	return dbInstance, config
 }
 
+func closeDBOnce(dbInstance *DB) func() {
+	closed := false
+	return func() {
+		if closed {
+			return
+		}
+		dbInstance.Close()
+		closed = true
+	}
+}
+
 func TestSerialisePutCommandRoundTrip(t *testing.T) {
 	payload := serialisePutCommand("key with spaces", "value with spaces\nand newline")
 
@@ -41,16 +52,19 @@ func TestSerialisePutCommandRoundTrip(t *testing.T) {
 
 func TestReadLengthPrefixedStringMalformedPayload(t *testing.T) {
 	testCases := []struct {
-		name string
-		buf  []byte
+		name        string
+		buf         []byte
+		expectedErr string
 	}{
 		{
-			name: "missing length",
-			buf:  []byte{0, 0, 0},
+			name:        "missing length",
+			buf:         []byte{0, 0, 0},
+			expectedErr: "malformed WAL command: missing uint32",
 		},
 		{
-			name: "string length exceeds payload",
-			buf:  []byte{0, 0, 0, 5, 'a'},
+			name:        "string length exceeds payload",
+			buf:         []byte{0, 0, 0, 5, 'a'},
+			expectedErr: "malformed WAL command: string length exceeds payload",
 		},
 	}
 
@@ -58,12 +72,14 @@ func TestReadLengthPrefixedStringMalformedPayload(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			offset := 0
 			_, err := readLengthPrefixedString(tt.buf, &offset)
-			assert.Error(t, err)
+			assert.EqualError(t, err, tt.expectedErr)
 		})
 	}
 }
 
 func TestDeserialisePutCommandRejectsTrailingBytes(t *testing.T) {
+	// A valid PUT command should consume the full WAL payload. The extra byte
+	// simulates malformed data that the parser must not silently ignore.
 	payload := append(serialisePutCommand("key", "value"), 'x')
 
 	offset := 0
@@ -72,7 +88,7 @@ func TestDeserialisePutCommandRejectsTrailingBytes(t *testing.T) {
 	require.Equal(t, CmdPut, cmd)
 
 	_, _, err = deserialisePutCommand(payload, &offset)
-	assert.Error(t, err)
+	assert.EqualError(t, err, "malformed WAL command: unexpected trailing bytes")
 }
 
 func TestSerialiseTransactionCommitPayloadRoundTrip(t *testing.T) {
@@ -102,11 +118,13 @@ func TestSerialiseTransactionCommitPayloadRoundTrip(t *testing.T) {
 
 func TestDeserialiseTransactionCommandRejectsMalformedPayload(t *testing.T) {
 	_, err := deserialiseTransactionCommand([]byte{0, 0, 0})
-	assert.Error(t, err)
+	assert.EqualError(t, err, "malformed WAL command: missing uint32")
 }
 
 func TestDBRecoversPutValuesWithSpacesAndNewlines(t *testing.T) {
 	dbInstance, config := newDBForWalCommandTest(t)
+	closeDB := closeDBOnce(dbInstance)
+	defer closeDB()
 
 	expected := map[string]string{
 		"simple":          "value with spaces",
@@ -115,7 +133,7 @@ func TestDBRecoversPutValuesWithSpacesAndNewlines(t *testing.T) {
 	for key, value := range expected {
 		require.NoError(t, dbInstance.Put(key, value))
 	}
-	dbInstance.Close()
+	closeDB()
 
 	dbAfterRestart, err := NewDB(config)
 	require.NoError(t, err)
@@ -130,10 +148,12 @@ func TestDBRecoversPutValuesWithSpacesAndNewlines(t *testing.T) {
 
 func TestDBRecoversLatestValueAfterOverwrite(t *testing.T) {
 	dbInstance, config := newDBForWalCommandTest(t)
+	closeDB := closeDBOnce(dbInstance)
+	defer closeDB()
 
 	require.NoError(t, dbInstance.Put("same key", "old value"))
 	require.NoError(t, dbInstance.Put("same key", "new value\nwith newline"))
-	dbInstance.Close()
+	closeDB()
 
 	dbAfterRestart, err := NewDB(config)
 	require.NoError(t, err)
@@ -146,13 +166,15 @@ func TestDBRecoversLatestValueAfterOverwrite(t *testing.T) {
 
 func TestDBRecoversTransactionValuesWithSpacesAndNewlines(t *testing.T) {
 	dbInstance, config := newDBForWalCommandTest(t)
+	closeDB := closeDBOnce(dbInstance)
+	defer closeDB()
 
 	txn, err := dbInstance.Begin()
 	require.NoError(t, err)
 	require.NoError(t, txn.Put("txn key with spaces", "txn value with spaces"))
 	require.NoError(t, txn.Put("txn key newline", "txn value\nwith newline"))
 	require.NoError(t, txn.Commit())
-	dbInstance.Close()
+	closeDB()
 
 	dbAfterRestart, err := NewDB(config)
 	require.NoError(t, err)

--- a/db/wal_command_test.go
+++ b/db/wal_command_test.go
@@ -1,0 +1,168 @@
+package db
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/golang-db/sstable"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newDBForWalCommandTest(t *testing.T) (*DB, Config) {
+	t.Helper()
+
+	dir := t.TempDir()
+	config := Config{
+		SsTableConfig: sstable.Config{
+			DataFilesDirectory: filepath.Join(dir, "sstable"),
+		},
+		WalFilePath: filepath.Join(dir, "wal.log"),
+	}
+
+	dbInstance, err := NewDB(config)
+	require.NoError(t, err)
+	return dbInstance, config
+}
+
+func TestSerialisePutCommandRoundTrip(t *testing.T) {
+	payload := serialisePutCommand("key with spaces", "value with spaces\nand newline")
+
+	offset := 0
+	cmd, err := readLengthPrefixedString(payload, &offset)
+	require.NoError(t, err)
+	assert.Equal(t, CmdPut, cmd)
+
+	key, value, err := deserialisePutCommand(payload, &offset)
+	require.NoError(t, err)
+	assert.Equal(t, "key with spaces", key)
+	assert.Equal(t, "value with spaces\nand newline", value)
+}
+
+func TestReadLengthPrefixedStringMalformedPayload(t *testing.T) {
+	testCases := []struct {
+		name string
+		buf  []byte
+	}{
+		{
+			name: "missing length",
+			buf:  []byte{0, 0, 0},
+		},
+		{
+			name: "string length exceeds payload",
+			buf:  []byte{0, 0, 0, 5, 'a'},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			offset := 0
+			_, err := readLengthPrefixedString(tt.buf, &offset)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestDeserialisePutCommandRejectsTrailingBytes(t *testing.T) {
+	payload := append(serialisePutCommand("key", "value"), 'x')
+
+	offset := 0
+	cmd, err := readLengthPrefixedString(payload, &offset)
+	require.NoError(t, err)
+	require.Equal(t, CmdPut, cmd)
+
+	_, _, err = deserialisePutCommand(payload, &offset)
+	assert.Error(t, err)
+}
+
+func TestSerialiseTransactionCommitPayloadRoundTrip(t *testing.T) {
+	payload := serialiseTransactionCommitPayload(map[string]string{
+		"txn key with spaces": "txn value with spaces",
+		"txn key newline":     "txn value\nwith newline",
+	})
+
+	offset := 0
+	cmd, err := readLengthPrefixedString(payload, &offset)
+	require.NoError(t, err)
+	assert.Equal(t, CmdTransaction, cmd)
+
+	putCmds, err := deserialiseTransactionCommand(payload[offset:])
+	require.NoError(t, err)
+
+	actual := map[string]string{}
+	for _, putCmd := range putCmds {
+		actual[putCmd.key] = putCmd.value
+	}
+
+	assert.Equal(t, map[string]string{
+		"txn key with spaces": "txn value with spaces",
+		"txn key newline":     "txn value\nwith newline",
+	}, actual)
+}
+
+func TestDeserialiseTransactionCommandRejectsMalformedPayload(t *testing.T) {
+	_, err := deserialiseTransactionCommand([]byte{0, 0, 0})
+	assert.Error(t, err)
+}
+
+func TestDBRecoversPutValuesWithSpacesAndNewlines(t *testing.T) {
+	dbInstance, config := newDBForWalCommandTest(t)
+
+	expected := map[string]string{
+		"simple":          "value with spaces",
+		"key with spaces": "value with\nnewline",
+	}
+	for key, value := range expected {
+		require.NoError(t, dbInstance.Put(key, value))
+	}
+	dbInstance.Close()
+
+	dbAfterRestart, err := NewDB(config)
+	require.NoError(t, err)
+	defer dbAfterRestart.Close()
+
+	for key, expectedValue := range expected {
+		value, err := dbAfterRestart.Get(key)
+		require.NoError(t, err)
+		assert.Equal(t, expectedValue, value)
+	}
+}
+
+func TestDBRecoversLatestValueAfterOverwrite(t *testing.T) {
+	dbInstance, config := newDBForWalCommandTest(t)
+
+	require.NoError(t, dbInstance.Put("same key", "old value"))
+	require.NoError(t, dbInstance.Put("same key", "new value\nwith newline"))
+	dbInstance.Close()
+
+	dbAfterRestart, err := NewDB(config)
+	require.NoError(t, err)
+	defer dbAfterRestart.Close()
+
+	value, err := dbAfterRestart.Get("same key")
+	require.NoError(t, err)
+	assert.Equal(t, "new value\nwith newline", value)
+}
+
+func TestDBRecoversTransactionValuesWithSpacesAndNewlines(t *testing.T) {
+	dbInstance, config := newDBForWalCommandTest(t)
+
+	txn, err := dbInstance.Begin()
+	require.NoError(t, err)
+	require.NoError(t, txn.Put("txn key with spaces", "txn value with spaces"))
+	require.NoError(t, txn.Put("txn key newline", "txn value\nwith newline"))
+	require.NoError(t, txn.Commit())
+	dbInstance.Close()
+
+	dbAfterRestart, err := NewDB(config)
+	require.NoError(t, err)
+	defer dbAfterRestart.Close()
+
+	value, err := dbAfterRestart.Get("txn key with spaces")
+	require.NoError(t, err)
+	assert.Equal(t, "txn value with spaces", value)
+
+	value, err = dbAfterRestart.Get("txn key newline")
+	require.NoError(t, err)
+	assert.Equal(t, "txn value\nwith newline", value)
+}

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func main() {
 	scanner := bufio.NewScanner(os.Stdin)
 	for scanner.Scan() {
 		line := scanner.Text()
-		args := strings.Split(line, " ")
+		args := strings.SplitN(line, " ", 3)
 		cmd := args[0]
 		breakLoop := false
 		switch cmd {


### PR DESCRIPTION
## Issue
WAL entries are length-framed, but the inner `PUT key value` payload was still serialized as text and replayed with string splitting. That made recovery fragile and broke keys/values containing spaces or newlines, especially after restart.

## Changes
- Store normal `PUT` WAL payloads as length-prefixed `command`, `key`, and `value` fields.
- Replay WAL entries by decoding structured fields instead of parsing human command text.
- Store transaction commit payloads as structured key/value pairs as well.
- Return transaction commit WAL write errors before mutating the memtable.
- Let the REPL preserve spaces in `PUT key value with spaces` by using `SplitN`.
- Add recovery tests for spaces, newlines, overwrites, malformed payloads, and transaction commits.

## Verification
- `/usr/local/go/bin/go test ./db -run "Test(SerialisePutCommandRoundTrip|ReadLengthPrefixedStringMalformedPayload|DeserialisePutCommandRejectsTrailingBytes|SerialiseTransactionCommitPayloadRoundTrip|DeserialiseTransactionCommandRejectsMalformedPayload|DBRecoversPutValuesWithSpacesAndNewlines|DBRecoversLatestValueAfterOverwrite|DBRecoversTransactionValuesWithSpacesAndNewlines)$"`
- `/usr/local/go/bin/go test ./... -run "^$"`

## Notes
- Existing old text-format WAL files are not replay-compatible with this new internal command payload format.
- Full `./...` currently has unrelated failures in `TestAppRestart` and `TestDb_ConcurrentPuts`.