### PR TITLE
fix: build secondary index prefix key from columns covered

### DIFF
--- a/db/secondary_index_test.go
+++ b/db/secondary_index_test.go
@@ -120,14 +120,14 @@ func TestSecondaryIndexBasedQueries(t *testing.T) {
 			TableName: "t1",
 			QueryConditions: []sqlparser.QueryCondition{
 				{
-					ColumnName: "c3",
-					QueryType:  sqlparser.Equals,
-					Value:      fmt.Sprintf("%d", i%5),
-				},
-				{
 					ColumnName: "c4",
 					QueryType:  sqlparser.Equals,
 					Value:      fmt.Sprintf("%d", i%2),
+				},
+				{
+					ColumnName: "c3",
+					QueryType:  sqlparser.Equals,
+					Value:      fmt.Sprintf("%d", i%5),
 				},
 			},
 		})

--- a/db/select.go
+++ b/db/select.go
@@ -132,12 +132,6 @@ func (db *DB) getQueryResultFromSecondaryIndexIfApplicable(tableName string, sel
 		return db.runFullTableScanAndFilterConditions(tableName, selectFromTableInput)
 	}
 	indexCoveredColValues := []string{}
-	// this is a bug. index prefix should be built with column value order as per the order of columns
-	// in the chosen secondary index and that too limited to to the columns covered in the secondary index.
-	// instead of this, we were just taking all of the columns in the input.
-	// this was problematic due to:
-	// 1. only a subset of columns could be covered in the chosen secondary index.
-	// 2. the column order in secondary index is what is actually inserted, the select query should also run prefix scan on the same order
 
 	for _, colName := range colsCoveredInSecIndex {
 		for _, condition := range selectFromTableInput.QueryConditions {

--- a/db/select.go
+++ b/db/select.go
@@ -41,15 +41,12 @@ func getSecondaryIndexForQueryIfApplicable(selectFromTableInput sqlparser.Select
 	colsCoveredInCandidateSecondaryIndex := []string{}
 	for _, secondaryIndex := range secondaryIndexes {
 		secIdxColsCoveredFromInputQuery := []string{}
+		inputQueryColumn := map[string]bool{}
+		for _, qc := range selectFromTableInput.QueryConditions {
+			inputQueryColumn[qc.ColumnName] = true
+		}
 		for _, secIdxCol := range secondaryIndex.Columns {
-			colFoundInInputQuery := false
-			for _, qc := range selectFromTableInput.QueryConditions {
-				if qc.ColumnName == secIdxCol {
-					colFoundInInputQuery = true
-					break
-				}
-			}
-			if colFoundInInputQuery {
+			if inputQueryColumn[secIdxCol] {
 				secIdxColsCoveredFromInputQuery = append(secIdxColsCoveredFromInputQuery, secIdxCol)
 			} else {
 				// we are going through each column in the secondary index sequentially
@@ -134,11 +131,22 @@ func (db *DB) getQueryResultFromSecondaryIndexIfApplicable(tableName string, sel
 	if secondaryIndex == nil {
 		return db.runFullTableScanAndFilterConditions(tableName, selectFromTableInput)
 	}
-	columnValues := []string{}
-	for _, condition := range selectFromTableInput.QueryConditions {
-		columnValues = append(columnValues, condition.Value)
+	indexCoveredColValues := []string{}
+	// this is a bug. index prefix should be built with column value order as per the order of columns
+	// in the chosen secondary index and that too limited to to the columns covered in the secondary index.
+	// instead of this, we were just taking all of the columns in the input.
+	// this was problematic due to:
+	// 1. only a subset of columns could be covered in the chosen secondary index.
+	// 2. the column order in secondary index is what is actually inserted, the select query should also run prefix scan on the same order
+
+	for _, colName := range colsCoveredInSecIndex {
+		for _, condition := range selectFromTableInput.QueryConditions {
+			if condition.ColumnName == colName {
+				indexCoveredColValues = append(indexCoveredColValues, condition.Value)
+			}
+		}
 	}
-	prefixKey := getSecondaryIndexKeyOrPrefix(tableName, secondaryIndex.IndexName, columnValues, "")
+	prefixKey := getSecondaryIndexKeyOrPrefix(tableName, secondaryIndex.IndexName, indexCoveredColValues, "")
 	primaryKeyIds, err := db.secondaryIndexPrefixScan(prefixKey)
 	if err != nil {
 		return nil, err

--- a/docs/journal/part_create_index.md
+++ b/docs/journal/part_create_index.md
@@ -1,0 +1,3 @@
+`CREATE INDEX` is similar to `CREATE TABLE` with the fact that we persist the secondary index catalog. But there is an interesting case to be handled in `CREATE INDEX` which is not possible in `CREATE TABLE`. `CREATE INDEX` can be run at any stage of the table even when there are millions of rows while `CREATE TABLE` only runs when the table is created.
+
+This leads to us requiring backfill. And running backfill means we are firing multiple PUT operations on `_indexes:<table_name>` on a table potentially having millions of rows. While this backfill is happening, the keys could also get updated.

--- a/sstable/sstable.go
+++ b/sstable/sstable.go
@@ -418,13 +418,10 @@ func (st *SsTable) sequentiallyScanTableAndUpdateMap(ssTableFile *os.File, table
 		}
 		i += (4 + len(value))
 
-		fmt.Printf("key3333: %+v\n", key)
-		fmt.Printf("value3333: %+v\n", value)
 		if strings.HasPrefix(key, tableKey) {
 			// only set the key value pair if the key is not found
 			// this is because we are sequentially going through the newest file first
 			if _, ok := (tableMap[key]); !ok {
-				fmt.Printf("REACH_22222 %v %v\n", key, value)
 				tableMap[key] = value
 			}
 		} else {


### PR DESCRIPTION
**Issue:** During SELECT query for index scans, the index prefix key was being built by iterating through all columns in the query condition. The order of the prefix key was also the order in which query conditions were provided. 

This was problematic due to:
1. Only a subset of columns could be covered in the chosen secondary index and not all input query conditions. If only a subset of columns are covered, only those columns should be part of the prefix key.
2. During insertion, the column order in secondary index is as per the order in the secondary index. Hence, the SELECT query should also run prefix scan on the same secondary index order (even if all input query conditions are not covered).

**Resolution:**
Building secondary index prefix key during SELECT index scan from colums covered in the chosen secondary index. (`colsCoveredInSecIndex` variable already existed).

Updated existing UT to change the order of columns. The test was failing in master and passing in current branch.