### PR TITLE
MVCC V1: Memtable and WAL

### DIFF
--- a/application_restart_test.go
+++ b/application_restart_test.go
@@ -24,6 +24,7 @@ var testPaymentsTable = sqlparser.CreateTable{
 			DataType:   sqlparser.Bool,
 		},
 	},
+	SecondaryIndexes: []sqlparser.SecondaryIndex{},
 }
 
 var testRefundsTable = sqlparser.CreateTable{
@@ -39,6 +40,7 @@ var testRefundsTable = sqlparser.CreateTable{
 			DataType:   0,
 		},
 	},
+	SecondaryIndexes: []sqlparser.SecondaryIndex{},
 }
 
 func TestAppRestart(t *testing.T) {

--- a/db/db.go
+++ b/db/db.go
@@ -121,6 +121,10 @@ func (db *DB) Close() {
 	// todo: close all sstable files
 }
 
+func (txn *Transaction) Get(key string) (value string, err error) {
+
+}
+
 func (db *DB) Get(key string) (value string, err error) {
 	db.mu.RLock()
 	defer db.mu.RUnlock()

--- a/db/db.go
+++ b/db/db.go
@@ -55,7 +55,7 @@ func NewDB(config Config) (*DB, error) {
 	}
 	db.wal = wal
 
-	memTable, err := db.buildMemtableFromWal()
+	memTable, maxTxnId, err := db.buildMemtableFromWal()
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func NewDB(config Config) (*DB, error) {
 	}
 
 	db.transactionManager = transactionManager{
-		nextTransactionId:     1,
+		nextTransactionId:     maxTxnId + 1,
 		mu:                    sync.Mutex{},
 		keyVsLocksAcquiredMap: map[string]*LocksAcquired{},
 	}
@@ -229,36 +229,38 @@ func deserialisePutCommand(buf []byte, offset *int) (key, value string, err erro
 	return key, value, nil
 }
 
-func (db *DB) buildMemtableFromWal() (*memtable.Memtable, error) {
+func (db *DB) buildMemtableFromWal() (*memtable.Memtable, uint64, error) {
 	memTable := memtable.NewMemtable()
+	var maxTxnId uint64 = 0
 	for {
 		payload, err := db.wal.ReadEntry()
 		if err == io.EOF {
-			return &memTable, nil
+			return &memTable, maxTxnId, nil
 		}
 		// for now, I will abort even in case of partial write
 		// todo: in case of partial write we should just truncate that log.
 		// we can also do that as part of listening to signal SIGTERM and SIGKILL?
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 
 		offset := 0
 		cmd, err := readLengthPrefixedString(payload, &offset)
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		switch cmd {
 		case CmdTransaction:
 			txnId, putCmds, err := deserialiseTransactionCommand(payload[offset:])
 			if err != nil {
-				return nil, err
+				return nil, 0, err
 			}
 			for _, cmd := range putCmds {
 				memTable.Put(cmd.key, cmd.value, txnId)
+				maxTxnId = max(maxTxnId, txnId)
 			}
 		default:
-			return nil, fmt.Errorf("unknown WAL command: %s", cmd)
+			return nil, 0, fmt.Errorf("unknown WAL command: %s", cmd)
 		}
 	}
 }

--- a/db/db.go
+++ b/db/db.go
@@ -121,10 +121,6 @@ func (db *DB) Close() {
 	// todo: close all sstable files
 }
 
-func (txn *Transaction) Get(key string) (value string, err error) {
-
-}
-
 func (db *DB) Get(key string) (value string, err error) {
 	db.mu.RLock()
 	defer db.mu.RUnlock()
@@ -145,19 +141,14 @@ func (db *DB) createSsTableAndClearWalAndMemTable() error {
 }
 
 func (db *DB) Put(key, value string) error {
-	db.mu.Lock()
-	defer db.mu.Unlock()
-	if err := db.writeToWal(key, value); err != nil {
-		return errors.New("Something went wrong")
+	txn, err := db.Begin()
+	if err != nil {
+		return err
 	}
-	db.memTable.Put(key, value)
-
-	if db.memTable.ShouldFlush() {
-		if err := db.createSsTableAndClearWalAndMemTable(); err != nil {
-			return err
-		}
+	if err = txn.Put(key, value); err != nil {
+		return err
 	}
-	return nil
+	return txn.Commit()
 }
 
 func (db *DB) flushMemtableToSsTable() error {
@@ -182,6 +173,15 @@ func appendLengthPrefixedString(buf []byte, value string) []byte {
 	buf = binary.BigEndian.AppendUint32(buf, uint32(len(value)))
 	buf = append(buf, []byte(value)...)
 	return buf
+}
+
+func readUint64(buf []byte, offset *int) (uint64, error) {
+	if len(buf)-*offset < 8 {
+		return 0, errors.New("malformed WAL command: missing uint64")
+	}
+	value := binary.BigEndian.Uint64(buf[*offset : *offset+8])
+	*offset += 8
+	return value, nil
 }
 
 func readUint32(buf []byte, offset *int) (uint32, error) {
@@ -249,19 +249,13 @@ func (db *DB) buildMemtableFromWal() (*memtable.Memtable, error) {
 			return nil, err
 		}
 		switch cmd {
-		case CmdPut:
-			key, value, err := deserialisePutCommand(payload, &offset)
-			if err != nil {
-				return nil, err
-			}
-			memTable.Put(key, value)
 		case CmdTransaction:
-			putCmds, err := deserialiseTransactionCommand(payload[offset:])
+			txnId, putCmds, err := deserialiseTransactionCommand(payload[offset:])
 			if err != nil {
 				return nil, err
 			}
 			for _, cmd := range putCmds {
-				memTable.Put(cmd.key, cmd.value)
+				memTable.Put(cmd.key, cmd.value, txnId)
 			}
 		default:
 			return nil, fmt.Errorf("unknown WAL command: %s", cmd)

--- a/db/db.go
+++ b/db/db.go
@@ -79,6 +79,10 @@ func NewDB(config Config) (*DB, error) {
 	return &db, err
 }
 
+func (db *DB) GetNextTransactionId() uint64 {
+	return db.transactionManager.nextTransactionId
+}
+
 func (db *DB) getTableNameVsSchemaMap() (map[string]sqlparser.CreateTable, error) {
 	tableNameVsSchemaMap := map[string]sqlparser.CreateTable{}
 	tablesString, err := db.Get(CatalogKey)
@@ -152,6 +156,8 @@ func (db *DB) Put(key, value string) error {
 }
 
 func (db *DB) flushMemtableToSsTable() error {
+	// todo: when we start writing txnId to sstable, we also need to persist maxTxnId in manifest file.
+	// and utilise that during application bootup to identify the maxTxnId.
 	ssTableFile, err := db.ssTable.NewFile()
 	if err != nil {
 		return err
@@ -255,9 +261,9 @@ func (db *DB) buildMemtableFromWal() (*memtable.Memtable, uint64, error) {
 			if err != nil {
 				return nil, 0, err
 			}
+			maxTxnId = max(maxTxnId, txnId)
 			for _, cmd := range putCmds {
 				memTable.Put(cmd.key, cmd.value, txnId)
-				maxTxnId = max(maxTxnId, txnId)
 			}
 		default:
 			return nil, 0, fmt.Errorf("unknown WAL command: %s", cmd)

--- a/db/select.go
+++ b/db/select.go
@@ -161,8 +161,23 @@ func (db *DB) getQueryResultFromSecondaryIndexIfApplicable(tableName string, sel
 		colsCoveredInSecIndex, queryResult)
 }
 
-// todo: without index scan, AND queries support to be added.
 func (db *DB) selectFromTable(selectFromTableInput sqlparser.SelectFromTable) ([][]string, error) {
+	txn, err := db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	res, err := txn.selectFromTable(selectFromTableInput)
+	if err != nil {
+		txn.Rollback()
+		return nil, err
+	}
+	err = txn.Commit()
+	return res, err
+}
+
+// todo: without index scan, AND queries support to be added.
+func (txn *Transaction) selectFromTable(selectFromTableInput sqlparser.SelectFromTable) ([][]string, error) {
+	db := txn.db
 	tableName := selectFromTableInput.TableName
 	schema, ok := db.tableNameVsSchemaMap[selectFromTableInput.TableName]
 	pkPos := schema.PrimaryKeyColumnPosition

--- a/db/select.go
+++ b/db/select.go
@@ -20,13 +20,13 @@ func isFullTableScanQuery(selectFromTableInput sqlparser.SelectFromTable) bool {
 	return len(selectFromTableInput.QueryConditions) == 0
 }
 
-func (db *DB) getRowForPrimaryKey(tableName, primaryKeyId string) ([]string, error) {
+func (txn *Transaction) getRowForPrimaryKey(tableName, primaryKeyId string) ([]string, error) {
 	key := fmt.Sprintf("%s:%s", tableName, primaryKeyId)
-	value, err := db.Get(key)
+	value, err := txn.Get(key)
 	if err != nil {
 		return nil, err
 	}
-	rowValues, err := db.deserializeRowValues(tableName, value)
+	rowValues, err := txn.db.deserializeRowValues(tableName, value)
 	if err != nil {
 		return nil, err
 	}
@@ -126,10 +126,10 @@ func (db *DB) runFullTableScanAndFilterConditions(tableName string, selectFromTa
 }
 
 // todo: not solving for RANGE queries within secondary index or primary key right now.
-func (db *DB) getQueryResultFromSecondaryIndexIfApplicable(tableName string, selectFromTableInput sqlparser.SelectFromTable, schema sqlparser.CreateTable) ([][]string, error) {
+func (txn *Transaction) getQueryResultFromSecondaryIndexIfApplicable(tableName string, selectFromTableInput sqlparser.SelectFromTable, schema sqlparser.CreateTable) ([][]string, error) {
 	secondaryIndex, colsCoveredInSecIndex := getSecondaryIndexForQueryIfApplicable(selectFromTableInput, schema.SecondaryIndexes)
 	if secondaryIndex == nil {
-		return db.runFullTableScanAndFilterConditions(tableName, selectFromTableInput)
+		return txn.db.runFullTableScanAndFilterConditions(tableName, selectFromTableInput)
 	}
 	indexCoveredColValues := []string{}
 
@@ -141,14 +141,14 @@ func (db *DB) getQueryResultFromSecondaryIndexIfApplicable(tableName string, sel
 		}
 	}
 	prefixKey := getSecondaryIndexKeyOrPrefix(tableName, secondaryIndex.IndexName, indexCoveredColValues, "")
-	primaryKeyIds, err := db.secondaryIndexPrefixScan(prefixKey)
+	primaryKeyIds, err := txn.db.secondaryIndexPrefixScan(prefixKey)
 	if err != nil {
 		return nil, err
 	}
 	// Run GET query for each primary key id separately and combine the result of each.
 	queryResult := [][]string{}
 	for _, pkId := range primaryKeyIds {
-		rowValues, err := db.getRowForPrimaryKey(tableName, pkId)
+		rowValues, err := txn.getRowForPrimaryKey(tableName, pkId)
 		if err != nil {
 			return nil, err
 		}
@@ -157,7 +157,7 @@ func (db *DB) getQueryResultFromSecondaryIndexIfApplicable(tableName string, sel
 	if allColumnsCoveredBySecondaryIndex(secondaryIndex, colsCoveredInSecIndex) {
 		return queryResult, nil
 	}
-	return db.filterQueryConditions(tableName, selectFromTableInput.QueryConditions,
+	return txn.db.filterQueryConditions(tableName, selectFromTableInput.QueryConditions,
 		colsCoveredInSecIndex, queryResult)
 }
 
@@ -196,7 +196,7 @@ func (txn *Transaction) selectFromTable(selectFromTableInput sqlparser.SelectFro
 	}
 	// todo: not solving for returning limited columns right now
 	if isPointedPrimaryKeyQuery(selectFromTableInput, pkColumnName) {
-		rowValues, err := db.getRowForPrimaryKey(tableName, selectFromTableInput.QueryConditions[0].Value)
+		rowValues, err := txn.getRowForPrimaryKey(tableName, selectFromTableInput.QueryConditions[0].Value)
 		if err != nil {
 			return nil, err
 		}
@@ -206,7 +206,7 @@ func (txn *Transaction) selectFromTable(selectFromTableInput sqlparser.SelectFro
 		return db.fullTableScan(tableName)
 	}
 
-	return db.getQueryResultFromSecondaryIndexIfApplicable(tableName, selectFromTableInput, schema)
+	return txn.getQueryResultFromSecondaryIndexIfApplicable(tableName, selectFromTableInput, schema)
 }
 
 // value: [value1][size_of_value2][value2][value3]

--- a/db/transaction.go
+++ b/db/transaction.go
@@ -164,7 +164,6 @@ func (txn *Transaction) Rollback() {
 // [length_of_command][command="TRANSACTION"][64_bit_transaction_id][number_of_writes]
 // [key_length_for_1st][key_for_1st][value_length_for_1st][value_for_1st]...
 func serialiseTransactionCommitPayload(writeMap map[string]string, txnId uint64) []byte {
-	// todo: add txnId in WAL
 	buf := []byte{}
 	buf = appendLengthPrefixedString(buf, CmdTransaction)
 	buf = binary.BigEndian.AppendUint64(buf, txnId)

--- a/db/transaction.go
+++ b/db/transaction.go
@@ -161,11 +161,13 @@ func (txn *Transaction) Rollback() {
 }
 
 // payload structure:
-// [length_of_command][command="TRANSACTION"][number_of_writes]
+// [length_of_command][command="TRANSACTION"][64_bit_transaction_id][number_of_writes]
 // [key_length_for_1st][key_for_1st][value_length_for_1st][value_for_1st]...
-func serialiseTransactionCommitPayload(writeMap map[string]string) []byte {
+func serialiseTransactionCommitPayload(writeMap map[string]string, txnId uint64) []byte {
+	// todo: add txnId in WAL
 	buf := []byte{}
 	buf = appendLengthPrefixedString(buf, CmdTransaction)
+	buf = binary.BigEndian.AppendUint64(buf, txnId)
 	buf = binary.BigEndian.AppendUint32(buf, uint32(len(writeMap)))
 
 	for key, value := range writeMap {
@@ -176,21 +178,25 @@ func serialiseTransactionCommitPayload(writeMap map[string]string) []byte {
 }
 
 // [number_of_writes][key_length_for_1st][key_for_1st][value_length_for_1st][value_for_1st]...
-func deserialiseTransactionCommand(buf []byte) ([]walPutCommand, error) {
+func deserialiseTransactionCommand(buf []byte) (uint64, []walPutCommand, error) {
 	offset := 0
+	txnId, err := readUint64(buf, &offset)
+	if err != nil {
+		return 0, nil, err
+	}
 	numWrites, err := readUint32(buf, &offset)
 	if err != nil {
-		return nil, err
+		return 0, nil, err
 	}
 	putCmds := []walPutCommand{}
 	for j := 0; j < int(numWrites); j++ {
 		key, err := readLengthPrefixedString(buf, &offset)
 		if err != nil {
-			return nil, err
+			return 0, nil, err
 		}
 		value, err := readLengthPrefixedString(buf, &offset)
 		if err != nil {
-			return nil, err
+			return 0, nil, err
 		}
 		putCmds = append(putCmds, walPutCommand{
 			key:   key,
@@ -198,14 +204,14 @@ func deserialiseTransactionCommand(buf []byte) ([]walPutCommand, error) {
 		})
 	}
 	if offset != len(buf) {
-		return nil, errors.New("malformed WAL command: unexpected trailing bytes")
+		return 0, nil, errors.New("malformed WAL command: unexpected trailing bytes")
 	}
-	return putCmds, nil
+	return txnId, putCmds, nil
 }
 
 // necessary to do in a single WAL write for atomicity
 func (txn *Transaction) writeSingleWalEntryForCommit() error {
-	buf := serialiseTransactionCommitPayload(txn.bufferedWriteMap)
+	buf := serialiseTransactionCommitPayload(txn.bufferedWriteMap, txn.id)
 	return txn.db.wal.WriteEntry(buf)
 }
 
@@ -216,7 +222,7 @@ func (txn *Transaction) Commit() error {
 
 	// put in memtable done separately instead of db.Put as that would lead to separate writes in WAL
 	for key, value := range txn.bufferedWriteMap {
-		txn.db.memTable.Put(key, value)
+		txn.db.memTable.Put(key, value, txn.id)
 	}
 
 	if txn.db.memTable.ShouldFlush() {

--- a/db/wal_command_test.go
+++ b/db/wal_command_test.go
@@ -95,14 +95,15 @@ func TestSerialiseTransactionCommitPayloadRoundTrip(t *testing.T) {
 	payload := serialiseTransactionCommitPayload(map[string]string{
 		"txn key with spaces": "txn value with spaces",
 		"txn key newline":     "txn value\nwith newline",
-	})
+	}, 4)
 
 	offset := 0
 	cmd, err := readLengthPrefixedString(payload, &offset)
 	require.NoError(t, err)
 	assert.Equal(t, CmdTransaction, cmd)
 
-	putCmds, err := deserialiseTransactionCommand(payload[offset:])
+	txnId, putCmds, err := deserialiseTransactionCommand(payload[offset:])
+	assert.Equal(t, uint64(4), txnId)
 	require.NoError(t, err)
 
 	actual := map[string]string{}
@@ -116,8 +117,13 @@ func TestSerialiseTransactionCommitPayloadRoundTrip(t *testing.T) {
 	}, actual)
 }
 
-func TestDeserialiseTransactionCommandRejectsMalformedPayload(t *testing.T) {
-	_, err := deserialiseTransactionCommand([]byte{0, 0, 0})
+func TestDeserialiseTransactionCommandRejectsMalformedPayloadMissingTxnId(t *testing.T) {
+	_, _, err := deserialiseTransactionCommand([]byte{0, 0, 0, 0, 0, 0, 0})
+	assert.EqualError(t, err, "malformed WAL command: missing uint64")
+}
+
+func TestDeserialiseTransactionCommandRejectsMalformedPayloadMissingNumWrites(t *testing.T) {
+	_, _, err := deserialiseTransactionCommand([]byte{0, 0, 0, 0, 0, 0, 0, 1})
 	assert.EqualError(t, err, "malformed WAL command: missing uint32")
 }
 

--- a/db/wal_command_test.go
+++ b/db/wal_command_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/golang-db/sstable"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func newDBForWalCommandTest(t *testing.T) (*DB, Config) {
@@ -21,7 +20,7 @@ func newDBForWalCommandTest(t *testing.T) (*DB, Config) {
 	}
 
 	dbInstance, err := NewDB(config)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	return dbInstance, config
 }
 
@@ -41,11 +40,11 @@ func TestSerialisePutCommandRoundTrip(t *testing.T) {
 
 	offset := 0
 	cmd, err := readLengthPrefixedString(payload, &offset)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, CmdPut, cmd)
 
 	key, value, err := deserialisePutCommand(payload, &offset)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "key with spaces", key)
 	assert.Equal(t, "value with spaces\nand newline", value)
 }
@@ -84,8 +83,8 @@ func TestDeserialisePutCommandRejectsTrailingBytes(t *testing.T) {
 
 	offset := 0
 	cmd, err := readLengthPrefixedString(payload, &offset)
-	require.NoError(t, err)
-	require.Equal(t, CmdPut, cmd)
+	assert.NoError(t, err)
+	assert.Equal(t, CmdPut, cmd)
 
 	_, _, err = deserialisePutCommand(payload, &offset)
 	assert.EqualError(t, err, "malformed WAL command: unexpected trailing bytes")
@@ -99,12 +98,12 @@ func TestSerialiseTransactionCommitPayloadRoundTrip(t *testing.T) {
 
 	offset := 0
 	cmd, err := readLengthPrefixedString(payload, &offset)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, CmdTransaction, cmd)
 
 	txnId, putCmds, err := deserialiseTransactionCommand(payload[offset:])
 	assert.Equal(t, uint64(4), txnId)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	actual := map[string]string{}
 	for _, putCmd := range putCmds {
@@ -137,17 +136,17 @@ func TestDBRecoversPutValuesWithSpacesAndNewlines(t *testing.T) {
 		"key with spaces": "value with\nnewline",
 	}
 	for key, value := range expected {
-		require.NoError(t, dbInstance.Put(key, value))
+		assert.NoError(t, dbInstance.Put(key, value))
 	}
 	closeDB()
 
 	dbAfterRestart, err := NewDB(config)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	defer dbAfterRestart.Close()
 
 	for key, expectedValue := range expected {
 		value, err := dbAfterRestart.Get(key)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, expectedValue, value)
 	}
 }
@@ -157,16 +156,16 @@ func TestDBRecoversLatestValueAfterOverwrite(t *testing.T) {
 	closeDB := closeDBOnce(dbInstance)
 	defer closeDB()
 
-	require.NoError(t, dbInstance.Put("same key", "old value"))
-	require.NoError(t, dbInstance.Put("same key", "new value\nwith newline"))
+	assert.NoError(t, dbInstance.Put("same key", "old value"))
+	assert.NoError(t, dbInstance.Put("same key", "new value\nwith newline"))
 	closeDB()
 
 	dbAfterRestart, err := NewDB(config)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	defer dbAfterRestart.Close()
 
 	value, err := dbAfterRestart.Get("same key")
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "new value\nwith newline", value)
 }
 
@@ -176,21 +175,22 @@ func TestDBRecoversTransactionValuesWithSpacesAndNewlines(t *testing.T) {
 	defer closeDB()
 
 	txn, err := dbInstance.Begin()
-	require.NoError(t, err)
-	require.NoError(t, txn.Put("txn key with spaces", "txn value with spaces"))
-	require.NoError(t, txn.Put("txn key newline", "txn value\nwith newline"))
-	require.NoError(t, txn.Commit())
+	assert.NoError(t, err)
+	assert.NoError(t, txn.Put("txn key with spaces", "txn value with spaces"))
+	assert.NoError(t, txn.Put("txn key newline", "txn value\nwith newline"))
+	assert.NoError(t, txn.Commit())
 	closeDB()
 
 	dbAfterRestart, err := NewDB(config)
-	require.NoError(t, err)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(2), dbAfterRestart.GetNextTransactionId())
 	defer dbAfterRestart.Close()
 
 	value, err := dbAfterRestart.Get("txn key with spaces")
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "txn value with spaces", value)
 
 	value, err = dbAfterRestart.Get("txn key newline")
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "txn value\nwith newline", value)
 }

--- a/docs/journal/part_5_1_test_plan.md
+++ b/docs/journal/part_5_1_test_plan.md
@@ -309,3 +309,5 @@ ok      github.com/golang-db/db 55.102s coverage: 70.9% of statements
         github.com/golang-db/memtable           coverage: 0.0% of statements
         github.com/golang-db/sstable            coverage: 0.0% of statements
 ok      github.com/golang-db/wal        0.987s  coverage: 77.6% of statements
+
+/usr/local/go/bin/go run main.go

--- a/docs/journal/part_mvcc.md
+++ b/docs/journal/part_mvcc.md
@@ -439,3 +439,6 @@ The only way to improve performance is to drop locks entirely
 7. Compaction: snapshot-aware version cleanup
 8. The tests should be solid to actually test for committed reads with two transactions happening in parallel.
 9. Benchmarks: 2PL vs MVCC
+
+
+PostgreSQL uses 32-bit transaction IDs and that IS a real problem. At high TPS, 32-bit wraps around in weeks. This is the infamous XID wraparound problem — PostgreSQL must run VACUUM to reclaim old XIDs, and if VACUUM falls behind, the database shuts down to prevent corruption. It's one of PostgreSQL's biggest operational headaches.

--- a/docs/pr_descriptions/22.md
+++ b/docs/pr_descriptions/22.md
@@ -1,0 +1,47 @@
+## Context
+This is an initial PR for starting with implementing MVCC. The behaviour stays the same as earlier. We are not yet implementing any isolation levels like READ COMMITTED or REPEATABLE READ.
+
+The goal is to start storing the version in memtable and WAL and make it accessible for SSTable to also store version in the next PR. As of now, `Get` would return the value of the latest version which is exactly the same behaviour as we are doing today.
+
+Hence the success criteria is:
+1. All existing tests should pass.
+2. New tests added to assert version being saved properly also pass.
+
+## Transaction Put and Memtable Flow
+MVCC requires version (transactionId) for every `Put`. For MVCC `key --> value` is changed to `(key, version) --> value`. The reason for keeping version within the key and not value is that within a memtable, the key alone now cannot be the unique identifier, there can be multiple versions for the same key. But `(key, version)` can be the unique identifier.
+
+We were already storing transactionId for each transaction struct in-memory. Hence, when `txn.Put` is called, transactionId is already available to us.
+
+For simplicity, even db.Put now calls `txn.Put` and then `txn.Commit`. Hence that also has a transaction Id and we don't need to support two different cases: with and without transactionId. Each write operation now has a transactionId associated to it.
+
+As of now, we are only storing the version in memtable and WAL and not in SSTable. Storing and fetching version from SSTable will be taken up separately.
+
+The Memtable sort logic (`Next` function) is updated such that if key is the same, then the memtable is sorted in ascending order on the basis of version.
+
+## Get Flow
+While running `Memtable.Get` earlier, we could just fire the `Get` function of the btree as only one entry existed. Now that we have multiple entries for the same key, we can't use `Get` as we need the value for the latest version for the key being searched. 
+
+To do that, we implement `AscendGreaterOrEqual` and iterate to find the latest value which is the latest value which is equal to the key. Remember that we had sorted in ascending order on version if the key is same.
+
+## SELECT Path Changes
+We need to propagate the transactionId throughout the SELECT path for the 2 cases handled within SELECT: `Get` Flow and Prefix Scan. Current PR focuses on the both the cases for memtable.
+
+### Prefix Scan For Memtable
+Currently prefix scan maintains a map: `tableMap[key] = e.Value`. Since the transactionIds are sorted in ascending order, newer version will always override older version.
+Hence, we didn't require any new changes here.
+
+## WAL Serialisation And Deserialisation Logic Update
+As part of WAL payload, we have also started persisting the transaction ID. WAL serialisation and deserialisation are updated to both persist txnID and then extract it during application bootup.
+
+### Read Max Transaction Id From WAL
+During application restart, we need to resume the transaction ID from the last transaction and add 1. The latest transaction ID can be fetched from WAL when we are building memtable during application restart.
+
+But there is also an additional case where the WAL can be empty. In that case, we would need to refer the latest transaction ID from SSTable. But reading entire SSTable (newest file) just to fetch the latest transaction is not efficient. To solve for that, we can write the latest transaction ID found in the manifest file during SSTable flush. This additional case can only be solved once we start writing to SSTable.
+
+## What is intentionally not updated and will be taken up in next PRs
+
+1. SSTable Writes
+2. SSTable: Prefix Scan and Get 
+3. Visibility Logic
+4. Compaction
+5. Maintaining Transaction Snapshot

--- a/memtable/memtable.go
+++ b/memtable/memtable.go
@@ -1,7 +1,6 @@
 package memtable
 
 import (
-	"math"
 	"strings"
 
 	"github.com/google/btree"
@@ -24,7 +23,7 @@ type Entry struct {
 
 func (e *Entry) Less(than btree.Item) bool {
 	if e.Key == than.(*Entry).Key {
-		return e.TxnId > than.(*Entry).TxnId
+		return e.TxnId < than.(*Entry).TxnId
 	}
 	return e.Key < than.(*Entry).Key
 }
@@ -38,14 +37,14 @@ func NewMemtable() Memtable {
 func (m *Memtable) Get(key string) (string, bool) {
 	value := ""
 	found := false
-	m.tree.AscendGreaterOrEqual(&Entry{Key: key, TxnId: math.MaxUint64}, func(item btree.Item) bool {
+	m.tree.AscendGreaterOrEqual(&Entry{Key: key}, func(item btree.Item) bool {
 		e := item.(*Entry)
 		if e.Key != key {
 			return false
 		}
 		value = e.Value
 		found = true
-		return false
+		return true
 	})
 	return value, found
 }

--- a/memtable/memtable.go
+++ b/memtable/memtable.go
@@ -18,6 +18,7 @@ type Memtable struct {
 type Entry struct {
 	Key   string
 	Value string
+	TxnId uint64
 }
 
 func (e *Entry) Less(than btree.Item) bool {
@@ -31,6 +32,9 @@ func NewMemtable() Memtable {
 }
 
 func (m *Memtable) Get(key string) (string, bool) {
+	// todo: we would have to rely on prefix scan now
+	// return the latest version
+	// m.PrefixScan()
 	item := m.tree.Get(&Entry{Key: key})
 	if item == nil {
 		return "", false
@@ -47,10 +51,11 @@ func (m *Memtable) Iterate(fn func(key, value string)) {
 	})
 }
 
-func (m *Memtable) Put(key, value string) {
+func (m *Memtable) Put(key, value string, txnId uint64) {
 	entry := Entry{
 		Key:   key,
 		Value: value,
+		TxnId: txnId,
 	}
 	if old := m.tree.ReplaceOrInsert(&entry); old != nil {
 		m.size += (len(value))

--- a/memtable/memtable.go
+++ b/memtable/memtable.go
@@ -64,8 +64,7 @@ func (m *Memtable) Put(key, value string, txnId uint64) {
 		Value: value,
 		TxnId: txnId,
 	}
-	// todo: this logic needs to change
-	// INSERT query would be replacement now
+	// todo: revisit memtable flush condition logic after some research
 	if old := m.tree.ReplaceOrInsert(&entry); old != nil {
 		m.size += (len(value))
 		m.size -= (len(old.(*Entry).Value))

--- a/memtable/memtable.go
+++ b/memtable/memtable.go
@@ -1,6 +1,7 @@
 package memtable
 
 import (
+	"math"
 	"strings"
 
 	"github.com/google/btree"
@@ -22,6 +23,9 @@ type Entry struct {
 }
 
 func (e *Entry) Less(than btree.Item) bool {
+	if e.Key == than.(*Entry).Key {
+		return e.TxnId > than.(*Entry).TxnId
+	}
 	return e.Key < than.(*Entry).Key
 }
 
@@ -32,14 +36,18 @@ func NewMemtable() Memtable {
 }
 
 func (m *Memtable) Get(key string) (string, bool) {
-	// todo: we would have to rely on prefix scan now
-	// return the latest version
-	// m.PrefixScan()
-	item := m.tree.Get(&Entry{Key: key})
-	if item == nil {
-		return "", false
-	}
-	return item.(*Entry).Value, true
+	value := ""
+	found := false
+	m.tree.AscendGreaterOrEqual(&Entry{Key: key, TxnId: math.MaxUint64}, func(item btree.Item) bool {
+		e := item.(*Entry)
+		if e.Key != key {
+			return false
+		}
+		value = e.Value
+		found = true
+		return false
+	})
+	return value, found
 }
 
 // Iterate loops through each of the key, value pair in the memTable
@@ -57,6 +65,8 @@ func (m *Memtable) Put(key, value string, txnId uint64) {
 		Value: value,
 		TxnId: txnId,
 	}
+	// todo: this logic needs to change
+	// INSERT query would be replacement now
 	if old := m.tree.ReplaceOrInsert(&entry); old != nil {
 		m.size += (len(value))
 		m.size -= (len(old.(*Entry).Value))

--- a/memtable/memtable_test.go
+++ b/memtable/memtable_test.go
@@ -1,0 +1,19 @@
+package memtable
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMemtablePutAndGet(t *testing.T) {
+	mem := NewMemtable()
+
+	mem.Put("name", "Gagan", 0)
+	mem.Put("name", "Akshay", 1)
+	mem.Put("name", "Akash", 2)
+
+	value, found := mem.Get("name")
+	assert.Equal(t, true, found)
+	assert.Equal(t, "Akash", value)
+}

--- a/memtable/memtable_test.go
+++ b/memtable/memtable_test.go
@@ -6,14 +6,35 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMemtablePutAndGet(t *testing.T) {
+func TestGetReturnsLatestVersion(t *testing.T) {
 	mem := NewMemtable()
+	mem.Put("name", "Gagan", 1)
+	mem.Put("city", "Delhi", 2)
+	mem.Put("city", "Mumbai", 1)
+	mem.Put("name", "Akash", 3)
 
-	mem.Put("name", "Gagan", 0)
-	mem.Put("name", "Akshay", 1)
-	mem.Put("name", "Akash", 2)
+	name, foundName := mem.Get("name")
+	city, foundCity := mem.Get("city")
+	assert.Equal(t, "Akash", name)
+	assert.Equal(t, true, foundName)
+	assert.Equal(t, "Delhi", city)
+	assert.Equal(t, true, foundCity)
+}
 
-	value, found := mem.Get("name")
-	assert.Equal(t, true, found)
-	assert.Equal(t, "Akash", value)
+func TestPrefixScanReturnsLatestVersions(t *testing.T) {
+	mem := NewMemtable()
+	mem.Put("users:1", "Alice", 1)
+	mem.Put("users:2", "Bob", 2)
+	mem.Put("users:1", "Alice2", 3)
+
+	result := mem.PrefixScan("users:")
+	assert.Equal(t, "Alice2", result["users:1"])
+	assert.Equal(t, "Bob", result["users:2"])
+}
+
+func TestGetNonExistentKey(t *testing.T) {
+	mem := NewMemtable()
+	mem.Put("name", "Gagan", 1)
+	_, found := mem.Get("age")
+	assert.False(t, found)
 }

--- a/sstable/manifest.go
+++ b/sstable/manifest.go
@@ -12,6 +12,7 @@ type manifest struct {
 	// possible that 5.json has older data compared to 4.json
 	// FileNames will always have the oldest file first
 	FileNames []string `json:"file_names"`
+	// todo: MaxTxnId  uint64
 }
 
 func (st *SsTable) getManifest() (*manifest, error) {
@@ -30,6 +31,8 @@ func (st *SsTable) getManifest() (*manifest, error) {
 	if err != nil {
 		return nil, err
 	}
+	// todo: when we start writing txnId to sstable, we also need to persist maxTxnId in manifest file.
+	// and utilise that during application bootup to identify the maxTxnId.
 
 	var manifest manifest
 	err = json.Unmarshal(manifestBuf, &manifest)
@@ -37,6 +40,8 @@ func (st *SsTable) getManifest() (*manifest, error) {
 }
 
 func (st *SsTable) saveManifest() error {
+	// todo: when we start writing txnId to sstable, we also need to persist maxTxnId in manifest file.
+	// and utilise that during application bootup to identify the maxTxnId.
 	manifestJsonBuf, err := json.MarshalIndent(st.manifest, "", " ")
 	if err != nil {
 		return err


### PR DESCRIPTION
## Context
This is an initial PR for starting with implementing MVCC. The behaviour stays the same as earlier. We are not yet implementing any isolation levels like READ COMMITTED or REPEATABLE READ.

The goal is to start storing the version in memtable and WAL and make it accessible for SSTable to also store version in the next PR. As of now, `Get` would return the value of the latest version which is exactly the same behaviour as we are doing today.

Hence the success criteria is:
1. All existing tests should pass.
2. New tests added to assert version being saved properly also pass.

## Transaction Put and Memtable Flow
MVCC requires version (transactionId) for every `Put`. For MVCC `key --> value` is changed to `(key, version) --> value`. The reason for keeping version within the key and not value is that within a memtable, the key alone now cannot be the unique identifier, there can be multiple versions for the same key. But `(key, version)` can be the unique identifier.

We were already storing transactionId for each transaction struct in-memory. Hence, when `txn.Put` is called, transactionId is already available to us.

For simplicity, even db.Put now calls `txn.Put` and then `txn.Commit`. Hence that also has a transaction Id and we don't need to support two different cases: with and without transactionId. Each write operation now has a transactionId associated to it.

As of now, we are only storing the version in memtable and WAL and not in SSTable. Storing and fetching version from SSTable will be taken up separately.

The Memtable sort logic (`Next` function) is updated such that if key is the same, then the memtable is sorted in ascending order on the basis of version.

## Get Flow
While running `Memtable.Get` earlier, we could just fire the `Get` function of the btree as only one entry existed. Now that we have multiple entries for the same key, we can't use `Get` as we need the value for the latest version for the key being searched. 

To do that, we implement `AscendGreaterOrEqual` and iterate to find the latest value which is the latest value which is equal to the key. Remember that we had sorted in ascending order on version if the key is same.

## SELECT Path Changes
We need to propagate the transactionId throughout the SELECT path for the 2 cases handled within SELECT: `Get` Flow and Prefix Scan. Current PR focuses on the both the cases for memtable.

### Prefix Scan For Memtable
Currently prefix scan maintains a map: `tableMap[key] = e.Value`. Since the transactionIds are sorted in ascending order, newer version will always override older version.
Hence, we didn't require any new changes here.

## WAL Serialisation And Deserialisation Logic Update
As part of WAL payload, we have also started persisting the transaction ID. WAL serialisation and deserialisation are updated to both persist txnID and then extract it during application bootup.

### Read Max Transaction Id From WAL
During application restart, we need to resume the transaction ID from the last transaction and add 1. The latest transaction ID can be fetched from WAL when we are building memtable during application restart.

But there is also an additional case where the WAL can be empty. In that case, we would need to refer the latest transaction ID from SSTable. But reading entire SSTable (newest file) just to fetch the latest transaction is not efficient. To solve for that, we can write the latest transaction ID found in the manifest file during SSTable flush. This additional case can only be solved once we start writing to SSTable.

## What is intentionally not updated and will be taken up in next PRs

1. SSTable Writes
2. SSTable: Prefix Scan and Get 
3. Visibility Logic
4. Compaction
5. Maintaining Transaction Snapshot